### PR TITLE
feat: Added new NodeTypeField.php `normalizationContext` to alter normalization groups per field basis

### DIFF
--- a/bruno/Roadiz development app/WebResponse/Get a WebResponse.bru
+++ b/bruno/Roadiz development app/WebResponse/Get a WebResponse.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Get a Page by its path wrapped in a WebResponse object
+  name: Get a WebResponse
   type: http
   seq: 1
 }
@@ -12,19 +12,18 @@ get {
 
 params:query {
   path: /
-  ~path: /articles/article-with-attributes
+  ~properties[item][]: nodeReferences
+  ~properties[item][]: title
   ~properties[]: item
-  ~properties[item]: title
+  ~path: /articles/article-with-attributes
   ~properties[]: blocks
-  ~properties[item]: url
+  ~properties[item][]: url
   ~path: /contact
   ~_preview: 1
   ~path: /fr/articles/article-with-attributes
-  ~testsd: sd
   ~path: /fr/articles
   ~properties[item][]: nodeReferences
   ~path: /data:image/svg-xml
-  ~_locale: zh
 }
 
 auth:bearer {

--- a/composer.json
+++ b/composer.json
@@ -143,6 +143,7 @@
         "league/flysystem-aws-s3-v3": "^3.10",
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpstan/phpstan-symfony": "^1.1.8",
         "phpunit/phpunit": "^9.5",

--- a/config/api_resources/web_response.yml
+++ b/config/api_resources/web_response.yml
@@ -1,5 +1,7 @@
 resources:
     RZ\Roadiz\CoreBundle\Api\Model\WebResponse:
+        filters:
+            - app.property_filter
         graphQlOperations: {  }
         operations:
             article_get_by_path:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -32,3 +32,10 @@ services:
     app.serializer.normalizer.menu_link_path.json:
         class: 'App\Serializer\Normalizer\MenuLinkPathNormalizer'
         decorates: 'api_platform.serializer.normalizer.item'
+
+    app.property_filter:
+        parent: 'api_platform.serializer.property_filter'
+        tags: [ 'api_platform.filter' ]
+        autowire: false
+        autoconfigure: false
+        public: false

--- a/lib/DocGenerator/composer.json
+++ b/lib/DocGenerator/composer.json
@@ -23,7 +23,8 @@
         }
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.5.3"
+        "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2"
     },
     "extra": {
         "branch-alias": {

--- a/lib/Documents/composer.json
+++ b/lib/Documents/composer.json
@@ -46,6 +46,7 @@
         "doctrine/doctrine-bundle": "^2.8.1",
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpunit/phpunit": "^9.5"
     },

--- a/lib/DtsGenerator/composer.json
+++ b/lib/DtsGenerator/composer.json
@@ -7,7 +7,8 @@
         "symfony/http-foundation": "6.4.*"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.5.3"
+        "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2"
     },
     "license": "MIT",
     "authors": [

--- a/lib/EntityGenerator/composer.json
+++ b/lib/EntityGenerator/composer.json
@@ -36,6 +36,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpunit/phpunit": "^9.5",
         "api-platform/core": "~3.3.11"
     },

--- a/lib/EntityGenerator/src/Field/AbstractFieldGenerator.php
+++ b/lib/EntityGenerator/src/Field/AbstractFieldGenerator.php
@@ -93,6 +93,20 @@ abstract class AbstractFieldGenerator
         return null;
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function getNormalizationContext(): ?array
+    {
+        if (\method_exists($this->field, 'getNormalizationContext')) {
+            $normalizationContext = $this->field->getNormalizationContext();
+            if (\is_array($normalizationContext) && !empty($normalizationContext['groups'])) {
+                return $normalizationContext;
+            }
+        }
+        return null;
+    }
+
     protected function addFieldAttributes(Property $property, PhpNamespace $namespace, bool $exclude = false): self
     {
         if ($exclude) {
@@ -132,6 +146,16 @@ abstract class AbstractFieldGenerator
             if ($this->getSerializationMaxDepth() > 0) {
                 $property->addAttribute('Symfony\Component\Serializer\Attribute\MaxDepth', [
                     $this->getSerializationMaxDepth(),
+                ]);
+            }
+
+            /*
+             * Enable different serialization context for this field.
+             */
+            if (null !== $this->getNormalizationContext()) {
+                $property->addAttribute('Symfony\Component\Serializer\Attribute\Context', [
+                    'normalizationContext' => $this->getNormalizationContext(),
+                    'groups' => $this->getSerializationGroups(),
                 ]);
             }
         }

--- a/lib/EntityGenerator/src/Field/AbstractFieldGenerator.php
+++ b/lib/EntityGenerator/src/Field/AbstractFieldGenerator.php
@@ -104,6 +104,7 @@ abstract class AbstractFieldGenerator
                 return $normalizationContext;
             }
         }
+
         return null;
     }
 

--- a/lib/EntityGenerator/src/Field/CustomFormsFieldGenerator.php
+++ b/lib/EntityGenerator/src/Field/CustomFormsFieldGenerator.php
@@ -33,7 +33,6 @@ final class CustomFormsFieldGenerator extends AbstractFieldGenerator
         return $this;
     }
 
-
     protected function getNormalizationContext(): array
     {
         return [

--- a/lib/EntityGenerator/src/Field/CustomFormsFieldGenerator.php
+++ b/lib/EntityGenerator/src/Field/CustomFormsFieldGenerator.php
@@ -23,6 +23,25 @@ final class CustomFormsFieldGenerator extends AbstractFieldGenerator
         return $this;
     }
 
+    protected function addFieldAnnotation(Property $property): AbstractFieldGenerator
+    {
+        parent::addFieldAnnotation($property);
+
+        $property->addComment('');
+        $property->addComment('@var '.$this->options['custom_form_class'].'[]|null');
+
+        return $this;
+    }
+
+
+    protected function getNormalizationContext(): array
+    {
+        return [
+            'groups' => ['nodes_sources', 'urls'],
+            ...(parent::getNormalizationContext() ?? []),
+        ];
+    }
+
     protected function getDefaultSerializationGroups(): array
     {
         $groups = parent::getDefaultSerializationGroups();

--- a/lib/EntityGenerator/tests/Mocks/GeneratedNodesSources/NSMock.php
+++ b/lib/EntityGenerator/tests/Mocks/GeneratedNodesSources/NSMock.php
@@ -309,12 +309,18 @@ class NSMock extends NodesSources
     /**
      * Custom forms field.
      * (Virtual field, this var is a buffer)
+     *
+     * @var \mock\Entity\CustomForm[]|null
      */
     #[JMS\Exclude]
     #[Serializer\SerializedName(serializedName: 'theForms')]
     #[Serializer\Groups(['nodes_sources', 'nodes_sources_default', 'nodes_sources_custom_forms'])]
     #[ApiProperty(description: 'Custom forms field')]
     #[Serializer\MaxDepth(2)]
+    #[Serializer\Context(
+        normalizationContext: ['groups' => ['nodes_sources', 'urls']],
+        groups: ['nodes_sources', 'nodes_sources_default', 'nodes_sources_custom_forms'],
+    )]
     private ?array $theForms = null;
 
     /**

--- a/lib/EntityGenerator/tests/Mocks/GeneratedNodesSourcesWithRepository/NSMock.php
+++ b/lib/EntityGenerator/tests/Mocks/GeneratedNodesSourcesWithRepository/NSMock.php
@@ -309,12 +309,18 @@ class NSMock extends NodesSources
     /**
      * Custom forms field.
      * (Virtual field, this var is a buffer)
+     *
+     * @var \mock\Entity\CustomForm[]|null
      */
     #[JMS\Exclude]
     #[Serializer\SerializedName(serializedName: 'theForms')]
     #[Serializer\Groups(['nodes_sources', 'nodes_sources_default', 'nodes_sources_custom_forms'])]
     #[ApiProperty(description: 'Custom forms field')]
     #[Serializer\MaxDepth(2)]
+    #[Serializer\Context(
+        normalizationContext: ['groups' => ['nodes_sources', 'urls']],
+        groups: ['nodes_sources', 'nodes_sources_default', 'nodes_sources_custom_forms'],
+    )]
     private ?array $theForms = null;
 
     /**

--- a/lib/Jwt/composer.json
+++ b/lib/Jwt/composer.json
@@ -17,7 +17,8 @@
         "symfony/http-client": "6.4.*"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.5.3"
+        "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Markdown/composer.json
+++ b/lib/Markdown/composer.json
@@ -10,7 +10,8 @@
         "twig/twig": "^3.16"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.5.3"
+        "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2"
     },
     "license": "MIT",
     "authors": [

--- a/lib/Models/composer.json
+++ b/lib/Models/composer.json
@@ -32,6 +32,7 @@
         "doctrine/doctrine-bundle": "^2.8.1",
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpunit/phpunit": "^9.5"
     },
     "autoload": {

--- a/lib/OpenId/composer.json
+++ b/lib/OpenId/composer.json
@@ -30,7 +30,8 @@
         "symfony/security-http": "6.4.*"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.5.3"
+        "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Random/composer.json
+++ b/lib/Random/composer.json
@@ -17,7 +17,8 @@
         "ext-openssl": "*"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.5.3"
+        "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2"
     },
     "autoload": {
         "psr-4": {

--- a/lib/RoadizCompatBundle/composer.json
+++ b/lib/RoadizCompatBundle/composer.json
@@ -26,6 +26,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpstan/phpstan-symfony": "^1.1.8",
         "roadiz/doc-generator": "2.4.*",

--- a/lib/RoadizCoreBundle/composer.json
+++ b/lib/RoadizCoreBundle/composer.json
@@ -100,6 +100,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "6.4.*",

--- a/lib/RoadizCoreBundle/migrations/Version20241218095458.php
+++ b/lib/RoadizCoreBundle/migrations/Version20241218095458.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RZ\Roadiz\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241218095458 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Added normalization_context to NodeTypeField';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE node_type_fields ADD normalization_context JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE node_type_fields DROP normalization_context');
+    }
+}

--- a/lib/RoadizCoreBundle/src/Entity/NodeTypeField.php
+++ b/lib/RoadizCoreBundle/src/Entity/NodeTypeField.php
@@ -347,6 +347,7 @@ class NodeTypeField extends AbstractField implements NodeTypeFieldInterface, Ser
     public function setNormalizationContext(?array $normalizationContext): NodeTypeField
     {
         $this->normalizationContext = $normalizationContext;
+
         return $this;
     }
 
@@ -363,6 +364,7 @@ class NodeTypeField extends AbstractField implements NodeTypeFieldInterface, Ser
             $this->normalizationContext = null;
         }
         $this->normalizationContext['groups'] = $normalizationContextGroups;
+
         return $this;
     }
 }

--- a/lib/RoadizCoreBundle/src/Entity/NodeTypeField.php
+++ b/lib/RoadizCoreBundle/src/Entity/NodeTypeField.php
@@ -101,6 +101,14 @@ class NodeTypeField extends AbstractField implements NodeTypeFieldInterface, Ser
     #[
         Serializer\Groups(['node_type']),
         SymfonySerializer\Groups(['node_type']),
+        Serializer\Type('array<string, array>'),
+        ORM\Column(name: 'normalization_context', type: 'json', nullable: true)
+    ]
+    private ?array $normalizationContext = null;
+
+    #[
+        Serializer\Groups(['node_type']),
+        SymfonySerializer\Groups(['node_type']),
         Serializer\Type('int'),
         ORM\Column(name: 'serialization_max_depth', type: Types::SMALLINT, nullable: true)
     ]
@@ -328,6 +336,33 @@ class NodeTypeField extends AbstractField implements NodeTypeFieldInterface, Ser
     {
         $this->excludedFromSerialization = $excludedFromSerialization;
 
+        return $this;
+    }
+
+    public function getNormalizationContext(): ?array
+    {
+        return $this->normalizationContext;
+    }
+
+    public function setNormalizationContext(?array $normalizationContext): NodeTypeField
+    {
+        $this->normalizationContext = $normalizationContext;
+        return $this;
+    }
+
+    #[SymfonySerializer\Ignore]
+    public function getNormalizationContextGroups(): ?array
+    {
+        return $this->normalizationContext['groups'] ?? [];
+    }
+
+    #[SymfonySerializer\Ignore]
+    public function setNormalizationContextGroups(?array $normalizationContextGroups): NodeTypeField
+    {
+        if (null === $normalizationContextGroups) {
+            $this->normalizationContext = null;
+        }
+        $this->normalizationContext['groups'] = $normalizationContextGroups;
         return $this;
     }
 }

--- a/lib/RoadizFontBundle/composer.json
+++ b/lib/RoadizFontBundle/composer.json
@@ -51,6 +51,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpunit/phpunit": "^9.5",
         "roadiz/compat-bundle": "2.4.*",

--- a/lib/RoadizRozierBundle/composer.json
+++ b/lib/RoadizRozierBundle/composer.json
@@ -29,6 +29,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpstan/phpstan-symfony": "^1.1.8"
     },

--- a/lib/RoadizTwoFactorBundle/composer.json
+++ b/lib/RoadizTwoFactorBundle/composer.json
@@ -36,6 +36,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "phpunit/phpunit": "^9.5",
         "roadiz/doc-generator": "2.4.*",

--- a/lib/RoadizUserBundle/composer.json
+++ b/lib/RoadizUserBundle/composer.json
@@ -31,6 +31,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "roadiz/doc-generator": "2.4.*",
         "roadiz/entity-generator": "2.4.*",

--- a/lib/Rozier/composer.json
+++ b/lib/Rozier/composer.json
@@ -66,6 +66,7 @@
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.4",
         "phpstan/phpstan": "^1.5.3",
+        "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^1.3",
         "roadiz/entity-generator": "2.4.*",
         "roadiz/jwt": "2.4.*",

--- a/lib/Rozier/src/AjaxControllers/AjaxSearchController.php
+++ b/lib/Rozier/src/AjaxControllers/AjaxSearchController.php
@@ -65,12 +65,12 @@ final class AjaxSearchController extends AbstractAjaxController
         foreach ($nodesSources as $source) {
             $uniqueKey = null;
             if ($source instanceof NodesSources) {
-                $uniqueKey = 'n_' . $source->getNode()->getId();
+                $uniqueKey = 'n_'.$source->getNode()->getId();
                 if (!$this->security->isGranted(NodeVoter::READ, $source)) {
                     continue;
                 }
             } elseif ($source instanceof PersistableInterface) {
-                $uniqueKey = 'p_' . $source->getId();
+                $uniqueKey = 'p_'.$source->getId();
             }
             if (key_exists($uniqueKey, $data)) {
                 continue;

--- a/lib/Rozier/src/Forms/NodeTypeFieldSerializationType.php
+++ b/lib/Rozier/src/Forms/NodeTypeFieldSerializationType.php
@@ -60,6 +60,7 @@ final class NodeTypeFieldSerializationType extends AbstractType
         ])
         ->add('serializationGroups', CollectionType::class, [
             'label' => 'nodeTypeField.serializationGroups',
+            'help' => 'nodeTypeField.serializationGroups.help',
             'required' => false,
             'allow_add' => true,
             'allow_delete' => true,

--- a/lib/Rozier/src/Forms/NodeTypeFieldSerializationType.php
+++ b/lib/Rozier/src/Forms/NodeTypeFieldSerializationType.php
@@ -44,6 +44,20 @@ final class NodeTypeFieldSerializationType extends AbstractType
                 'placeholder' => 'enter_symfony_expression_language_with_object_as_var_name',
             ],
         ])
+        ->add('normalizationContextGroups', CollectionType::class, [
+            'label' => 'nodeTypeField.normalizationContextGroups',
+            'help' => 'nodeTypeField.normalizationContextGroups.help',
+            'required' => false,
+            'allow_add' => true,
+            'allow_delete' => true,
+            'attr' => [
+                'class' => 'rz-collection-form-type',
+            ],
+            'entry_options' => [
+                'label' => false,
+            ],
+            'entry_type' => TextType::class,
+        ])
         ->add('serializationGroups', CollectionType::class, [
             'label' => 'nodeTypeField.serializationGroups',
             'required' => false,

--- a/lib/Rozier/src/Forms/NodeTypeFieldSerializationType.php
+++ b/lib/Rozier/src/Forms/NodeTypeFieldSerializationType.php
@@ -24,6 +24,34 @@ final class NodeTypeFieldSerializationType extends AbstractType
             'help' => 'exclude_this_field_from_api_serialization',
             'required' => false,
         ])
+        ->add('serializationGroups', CollectionType::class, [
+            'label' => 'nodeTypeField.serializationGroups',
+            'help' => 'nodeTypeField.serializationGroups.help',
+            'required' => false,
+            'allow_add' => true,
+            'allow_delete' => true,
+            'attr' => [
+                'class' => 'rz-collection-form-type',
+            ],
+            'entry_options' => [
+                'label' => false,
+            ],
+            'entry_type' => TextType::class,
+        ])
+        ->add('normalizationContextGroups', CollectionType::class, [
+            'label' => 'nodeTypeField.normalizationContextGroups',
+            'help' => 'nodeTypeField.normalizationContextGroups.help',
+            'required' => false,
+            'allow_add' => true,
+            'allow_delete' => true,
+            'attr' => [
+                'class' => 'rz-collection-form-type',
+            ],
+            'entry_options' => [
+                'label' => false,
+            ],
+            'entry_type' => TextType::class,
+        ])
         ->add('serializationMaxDepth', IntegerType::class, [
             'label' => 'nodeTypeField.serializationMaxDepth',
             'required' => false,
@@ -43,34 +71,6 @@ final class NodeTypeFieldSerializationType extends AbstractType
             'attr' => [
                 'placeholder' => 'enter_symfony_expression_language_with_object_as_var_name',
             ],
-        ])
-        ->add('normalizationContextGroups', CollectionType::class, [
-            'label' => 'nodeTypeField.normalizationContextGroups',
-            'help' => 'nodeTypeField.normalizationContextGroups.help',
-            'required' => false,
-            'allow_add' => true,
-            'allow_delete' => true,
-            'attr' => [
-                'class' => 'rz-collection-form-type',
-            ],
-            'entry_options' => [
-                'label' => false,
-            ],
-            'entry_type' => TextType::class,
-        ])
-        ->add('serializationGroups', CollectionType::class, [
-            'label' => 'nodeTypeField.serializationGroups',
-            'help' => 'nodeTypeField.serializationGroups.help',
-            'required' => false,
-            'allow_add' => true,
-            'allow_delete' => true,
-            'attr' => [
-                'class' => 'rz-collection-form-type',
-            ],
-            'entry_options' => [
-                'label' => false,
-            ],
-            'entry_type' => TextType::class,
         ]);
     }
 

--- a/lib/Rozier/src/Resources/translations/messages.en.xlf
+++ b/lib/Rozier/src/Resources/translations/messages.en.xlf
@@ -402,6 +402,23 @@
         <source>nodeTypeField.defaultValues</source>
         <target state="translated">Advanced field configuration</target>
       </trans-unit>
+      <trans-unit xml:space="preserve" id="nodeTypeField.normalizationContextGroups">
+        <source>nodeTypeField.normalizationContextGroups</source>
+        <target state="final">Custom serialization context (groups)</target>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="nodeTypeField.normalizationContextGroups.help">
+        <source>nodeTypeField.normalizationContextGroups.help</source>
+        <target state="final">Changes the serialization context for the contents of this field.</target>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="nodeTypeField.serializationGroups.help">
+        <source>nodeTypeField.serializationGroups.help</source>
+        <target state="final">
+            Select the serialization groups for which this field will be serialized.
+            By default, this field will be serialized for the *nodes_sources* and *nodes_sources_default* groups.
+            If the field is part of a Field Group, it will use the *nodes_sources_{group name}* group instead of *nodes_sources_default*.
+            which will hide the field from an API collection operation.
+        </target>
+      </trans-unit>
       <trans-unit xml:space="preserve" id="101" approved="yes">
         <source>enter_values_comma_separated</source>
         <target state="final">Enter each values separated with commas.</target>

--- a/lib/Rozier/src/Resources/translations/messages.en.xlf
+++ b/lib/Rozier/src/Resources/translations/messages.en.xlf
@@ -413,7 +413,7 @@
       <trans-unit xml:space="preserve" id="nodeTypeField.serializationGroups.help">
         <source>nodeTypeField.serializationGroups.help</source>
         <target state="final">
-            Select the serialization groups for which this field will be serialized.
+            Select the [serialization groups](https://docs.roadiz.io/en/latest/developer/api/serialization.html#serialization-groups) for which this field will be serialized.
             By default, this field will be serialized for the *nodes_sources* and *nodes_sources_default* groups.
             If the field is part of a Field Group, it will use the *nodes_sources_{group name}* group instead of *nodes_sources_default*.
             which will hide the field from an API collection operation.

--- a/lib/Rozier/src/Resources/translations/messages.fr.xlf
+++ b/lib/Rozier/src/Resources/translations/messages.fr.xlf
@@ -402,6 +402,23 @@
         <source>nodeTypeField.defaultValues</source>
         <target state="final">Configuration avancée</target>
       </trans-unit>
+      <trans-unit xml:space="preserve" id="nodeTypeField.normalizationContextGroups">
+        <source>nodeTypeField.normalizationContextGroups</source>
+        <target state="final">Contexte personalisé de sérialisation (groupes)</target>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="nodeTypeField.normalizationContextGroups.help">
+        <source>nodeTypeField.normalizationContextGroups.help</source>
+        <target state="final">Permet de modifier le contexte de sérialisation pour le contenu de ce champ.</target>
+      </trans-unit>
+      <trans-unit xml:space="preserve" id="nodeTypeField.serializationGroups.help">
+        <source>nodeTypeField.serializationGroups.help</source>
+        <target state="final">
+            Permet de choisir des groupes de sérialisation pour lesquels ce champ sera sérialisé.
+            Par défaut, ce champ sera sérialisé pour les groupes *nodes_sources* et *nodes_sources_default*.
+            Si le champ fait partie d'un Groupe de champ, il utilisera le groupe *nodes_sources_{nom du groupe}* à la place de *nodes_sources_default*
+            ce qui cachera le champ depuis une opération API de type Collection.
+        </target>
+      </trans-unit>
       <trans-unit xml:space="preserve" id="101" approved="yes">
         <source>enter_values_comma_separated</source>
         <target state="final">Entrez les valeurs séparées par des virgules…</target>

--- a/lib/Rozier/src/Resources/translations/messages.fr.xlf
+++ b/lib/Rozier/src/Resources/translations/messages.fr.xlf
@@ -413,7 +413,7 @@
       <trans-unit xml:space="preserve" id="nodeTypeField.serializationGroups.help">
         <source>nodeTypeField.serializationGroups.help</source>
         <target state="final">
-            Permet de choisir des groupes de sérialisation pour lesquels ce champ sera sérialisé.
+            Permet de choisir des [groupes de sérialisation](https://docs.roadiz.io/en/latest/developer/api/serialization.html#serialization-groups) pour lesquels ce champ sera sérialisé.
             Par défaut, ce champ sera sérialisé pour les groupes *nodes_sources* et *nodes_sources_default*.
             Si le champ fait partie d'un Groupe de champ, il utilisera le groupe *nodes_sources_{nom du groupe}* à la place de *nodes_sources_default*
             ce qui cachera le champ depuis une opération API de type Collection.

--- a/lib/Rozier/src/Resources/translations/messages.xlf
+++ b/lib/Rozier/src/Resources/translations/messages.xlf
@@ -104,6 +104,7 @@
             <trans-unit xml:space="preserve" id="nodeTypeField.defaultValues"><source>nodeTypeField.defaultValues</source></trans-unit>
             <trans-unit xml:space="preserve" id="nodeTypeField.normalizationContextGroups"><source>nodeTypeField.normalizationContextGroups</source></trans-unit>
             <trans-unit xml:space="preserve" id="nodeTypeField.normalizationContextGroups.help"><source>nodeTypeField.normalizationContextGroups.help</source></trans-unit>
+            <trans-unit xml:space="preserve" id="nodeTypeField.serializationGroups.help"><source>nodeTypeField.serializationGroups.help</source></trans-unit>
             <trans-unit xml:space="preserve" id="101"><source>enter_values_comma_separated</source></trans-unit>
             <trans-unit xml:space="preserve" id="102"><source>node.%name%.translated</source></trans-unit>
             <trans-unit xml:space="preserve" id="103"><source>node_source.%node_source%.updated.%translation%</source></trans-unit>

--- a/lib/Rozier/src/Resources/translations/messages.xlf
+++ b/lib/Rozier/src/Resources/translations/messages.xlf
@@ -102,6 +102,8 @@
             <trans-unit xml:space="preserve" id="100"><source>defaultValues</source></trans-unit>
             <trans-unit xml:space="preserve" id="customFormField.defaultValues"><source>customFormField.defaultValues</source></trans-unit>
             <trans-unit xml:space="preserve" id="nodeTypeField.defaultValues"><source>nodeTypeField.defaultValues</source></trans-unit>
+            <trans-unit xml:space="preserve" id="nodeTypeField.normalizationContextGroups"><source>nodeTypeField.normalizationContextGroups</source></trans-unit>
+            <trans-unit xml:space="preserve" id="nodeTypeField.normalizationContextGroups.help"><source>nodeTypeField.normalizationContextGroups.help</source></trans-unit>
             <trans-unit xml:space="preserve" id="101"><source>enter_values_comma_separated</source></trans-unit>
             <trans-unit xml:space="preserve" id="102"><source>node.%name%.translated</source></trans-unit>
             <trans-unit xml:space="preserve" id="103"><source>node_source.%node_source%.updated.%translation%</source></trans-unit>

--- a/lib/Rozier/src/Resources/views/node-type-fields/editBase.html.twig
+++ b/lib/Rozier/src/Resources/views/node-type-fields/editBase.html.twig
@@ -5,7 +5,8 @@
 {% block content %}
 <section class="content-global manage-node-type-field">
     <header class="content-header header-node-type-fields header-node-type-field-edit">
-         <h1 class="content-title node-type-field-edit-title">{{ "edit.nodeTypeField.%name%"|trans({'%name%': field.getName})|u.truncate(25, '[…]', true) }}</h1>
+         <h2 class="content-title">{{ nodeType.name }}</h2>
+         <h1 class="node-type-field-edit-title">{{ "edit.nodeTypeField.%name%"|trans({'%name%': field.getName})|u.truncate(25, '[…]', true) }}</h1>
          <a class="content-header-nav-back uk-navbar-content" href="{{ path('nodeTypeFieldsListPage', { nodeTypeId: nodeType.getId }) }}" title="{% trans %}back_to.nodeTypeFields{% endtrans %}" data-uk-tooltip="{animation:true}"><i class="uk-icon-rz-back-parent"></i></a>
     </header>
 

--- a/src/GeneratedEntity/NSMenuLink.php
+++ b/src/GeneratedEntity/NSMenuLink.php
@@ -53,8 +53,8 @@ class NSMenuLink extends NodesSources
     #[Serializer\SerializedName(serializedName: 'linkInternalReference')]
     #[Serializer\Groups(['urls'])]
     #[ApiProperty(description: 'Référence au nœud (Page ou Bloc de page)')]
-    #[Serializer\MaxDepth(2)]
-    #[Serializer\Context(normalizationContext: ['groups' => ['urls', 'nodes_sources_default', 'nodes_sources_base']], groups: ['urls'])]
+    #[Serializer\MaxDepth(1)]
+    #[Serializer\Context(normalizationContext: ['groups' => ['urls', 'nodes_sources_base']], groups: ['urls'])]
     private ?array $linkInternalReferenceSources = null;
 
     /**
@@ -91,7 +91,7 @@ class NSMenuLink extends NodesSources
      * @return \RZ\Roadiz\CoreBundle\Entity\NodesSources[]
      */
     #[JMS\Groups(['urls'])]
-    #[JMS\MaxDepth(2)]
+    #[JMS\MaxDepth(1)]
     #[JMS\VirtualProperty]
     #[JMS\SerializedName('linkInternalReference')]
     #[JMS\Type('array<RZ\Roadiz\CoreBundle\Entity\NodesSources>')]

--- a/src/GeneratedEntity/NSMenuLink.php
+++ b/src/GeneratedEntity/NSMenuLink.php
@@ -48,14 +48,13 @@ class NSMenuLink extends NodesSources
      * linkInternalReferenceSources NodesSources direct field buffer.
      * @var \RZ\Roadiz\CoreBundle\Entity\NodesSources[]|null
      * Référence au nœud (Page ou Bloc de page).
-     * Default values:
-     * Page, Article, ArticleContainer, Offer
      */
     #[JMS\Exclude]
     #[Serializer\SerializedName(serializedName: 'linkInternalReference')]
-    #[Serializer\Groups(['nodes_sources', 'nodes_sources_default', 'nodes_sources_nodes'])]
+    #[Serializer\Groups(['urls'])]
     #[ApiProperty(description: 'Référence au nœud (Page ou Bloc de page)')]
     #[Serializer\MaxDepth(2)]
+    #[Serializer\Context(normalizationContext: ['groups' => ['urls', 'nodes_sources_default', 'nodes_sources_base']], groups: ['urls'])]
     private ?array $linkInternalReferenceSources = null;
 
     /**
@@ -91,7 +90,7 @@ class NSMenuLink extends NodesSources
     /**
      * @return \RZ\Roadiz\CoreBundle\Entity\NodesSources[]
      */
-    #[JMS\Groups(['nodes_sources', 'nodes_sources_default', 'nodes_sources_nodes'])]
+    #[JMS\Groups(['urls'])]
     #[JMS\MaxDepth(2)]
     #[JMS\VirtualProperty]
     #[JMS\SerializedName('linkInternalReference')]

--- a/src/GeneratedEntity/NSPage.php
+++ b/src/GeneratedEntity/NSPage.php
@@ -125,16 +125,15 @@ class NSPage extends NodesSources
 
     /**
      * nodeReferencesSources NodesSources direct field buffer.
-     * @var \App\GeneratedEntity\NSPage[]|null
+     * @var \RZ\Roadiz\CoreBundle\Entity\NodesSources[]|null
      * References.
-     * Default values:
-     * Page
      */
     #[JMS\Exclude]
     #[Serializer\SerializedName(serializedName: 'nodeReferences')]
-    #[Serializer\Groups(['nodes_sources', 'nodes_sources_default', 'nodes_sources_nodes'])]
+    #[Serializer\Groups(['page_get_by_path'])]
     #[ApiProperty(description: 'References')]
-    #[Serializer\MaxDepth(2)]
+    #[Serializer\MaxDepth(1)]
+    #[Serializer\Context(normalizationContext: ['groups' => ['page_get_by_path', 'urls', 'nodes_sources_base']], groups: ['page_get_by_path'])]
     private ?array $nodeReferencesSources = null;
 
     /**
@@ -603,10 +602,10 @@ class NSPage extends NodesSources
     }
 
     /**
-     * @return \App\GeneratedEntity\NSPage[]
+     * @return \RZ\Roadiz\CoreBundle\Entity\NodesSources[]
      */
-    #[JMS\Groups(['nodes_sources', 'nodes_sources_default', 'nodes_sources_nodes'])]
-    #[JMS\MaxDepth(2)]
+    #[JMS\Groups(['page_get_by_path'])]
+    #[JMS\MaxDepth(1)]
     #[JMS\VirtualProperty]
     #[JMS\SerializedName('nodeReferences')]
     #[JMS\Type('array<RZ\Roadiz\CoreBundle\Entity\NodesSources>')]
@@ -615,7 +614,7 @@ class NSPage extends NodesSources
         if (null === $this->nodeReferencesSources) {
             if (null !== $this->objectManager) {
                 $this->nodeReferencesSources = $this->objectManager
-                    ->getRepository(\App\GeneratedEntity\NSPage::class)
+                    ->getRepository(\RZ\Roadiz\CoreBundle\Entity\NodesSources::class)
                     ->findByNodesSourcesAndFieldNameAndTranslation(
                         $this,
                         'node_references'
@@ -628,7 +627,7 @@ class NSPage extends NodesSources
     }
 
     /**
-     * @param \App\GeneratedEntity\NSPage[]|null $nodeReferencesSources
+     * @param \RZ\Roadiz\CoreBundle\Entity\NodesSources[]|null $nodeReferencesSources
      * @return $this
      */
     public function setNodeReferencesSources(?array $nodeReferencesSources): static

--- a/src/GeneratedEntity/NSPage.php
+++ b/src/GeneratedEntity/NSPage.php
@@ -174,12 +174,18 @@ class NSPage extends NodesSources
     /**
      * Custom form.
      * (Virtual field, this var is a buffer)
+     *
+     * @var \RZ\Roadiz\CoreBundle\Entity\CustomForm[]|null
      */
     #[JMS\Exclude]
     #[Serializer\SerializedName(serializedName: 'customForm')]
     #[Serializer\Groups(['nodes_sources', 'nodes_sources_default', 'nodes_sources_custom_forms'])]
     #[ApiProperty(description: 'Custom form')]
     #[Serializer\MaxDepth(2)]
+    #[Serializer\Context(
+        normalizationContext: ['groups' => ['nodes_sources', 'urls']],
+        groups: ['nodes_sources', 'nodes_sources_default', 'nodes_sources_custom_forms'],
+    )]
     private ?array $customForm = null;
 
     /**

--- a/src/Resources/node-types/MenuLink.json
+++ b/src/Resources/node-types/MenuLink.json
@@ -36,10 +36,10 @@
             "normalization_context": {
                 "groups": [
                     "urls",
-                    "nodes_sources_default",
                     "nodes_sources_base"
                 ]
             },
+            "serialization_max_depth": 1,
             "excluded_from_serialization": false,
             "indexed": false,
             "visible": true

--- a/src/Resources/node-types/MenuLink.json
+++ b/src/Resources/node-types/MenuLink.json
@@ -5,6 +5,7 @@
     "visible": false,
     "publishable": false,
     "attributable": true,
+    "sorting_attributes_by_weight": false,
     "reachable": false,
     "hiding_nodes": false,
     "hiding_non_reachable_nodes": false,
@@ -25,11 +26,20 @@
             "position": 2.0,
             "name": "link_internal_reference",
             "label": "R\u00e9f\u00e9rence au n\u0153ud (Page ou Bloc de page)",
-            "default_values": "Page, Article, ArticleContainer, Offer",
             "type": 13,
             "expanded": false,
             "universal": true,
             "exclude_from_search": false,
+            "serialization_groups": [
+                "urls"
+            ],
+            "normalization_context": {
+                "groups": [
+                    "urls",
+                    "nodes_sources_default",
+                    "nodes_sources_base"
+                ]
+            },
             "excluded_from_serialization": false,
             "indexed": false,
             "visible": true

--- a/src/Resources/node-types/Page.json
+++ b/src/Resources/node-types/Page.json
@@ -6,6 +6,7 @@
     "visible": true,
     "publishable": true,
     "attributable": true,
+    "sorting_attributes_by_weight": false,
     "reachable": true,
     "hiding_nodes": false,
     "hiding_non_reachable_nodes": true,
@@ -120,11 +121,21 @@
             "position": 9.0,
             "name": "node_references",
             "label": "References",
-            "default_values": "Page",
             "type": 13,
             "expanded": false,
             "universal": false,
             "exclude_from_search": false,
+            "serialization_groups": [
+                "page_get_by_path"
+            ],
+            "normalization_context": {
+                "groups": [
+                    "page_get_by_path",
+                    "urls",
+                    "nodes_sources_base"
+                ]
+            },
+            "serialization_max_depth": 1,
             "excluded_from_serialization": false,
             "indexed": false,
             "visible": true


### PR DESCRIPTION
We can optimize API responses by configuring serialization context per NodeType field. This will avoid heavy WebResponse resources. 