### PR TITLE
fix: Bug on traduction by default on nodeTags without default traduction

### DIFF
--- a/lib/RoadizCoreBundle/src/Repository/NodesSourcesRepository.php
+++ b/lib/RoadizCoreBundle/src/Repository/NodesSourcesRepository.php
@@ -592,7 +592,7 @@ class NodesSourcesRepository extends StatusAwareRepository
             ->setCacheable(true);
 
         $this->alterQueryBuilderWithAuthorizationChecker($qb);
-        if (!$this->previewResolver->isPreview()) {
+        if (!$this->previewResolver->isPreview() && !$this->isDisplayingAllNodesStatuses()) {
             $qb->andWhere($qb->expr()->eq(static::TRANSLATION_ALIAS.'.available', ':available'))
                 ->setParameter('available', true);
         }

--- a/lib/RoadizRozierBundle/src/Controller/Node/NodesTagsController.php
+++ b/lib/RoadizRozierBundle/src/Controller/Node/NodesTagsController.php
@@ -8,7 +8,6 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use RZ\Roadiz\CoreBundle\Entity\Node;
 use RZ\Roadiz\CoreBundle\Entity\NodesSources;
-use RZ\Roadiz\CoreBundle\Entity\Translation;
 use RZ\Roadiz\CoreBundle\Event\Node\NodeTaggedEvent;
 use RZ\Roadiz\CoreBundle\Node\NodeFactory;
 use RZ\Roadiz\CoreBundle\Repository\NodesSourcesRepository;
@@ -50,11 +49,14 @@ final class NodesTagsController extends AbstractController
             ->setDisplayingAllNodesStatuses(true)
             ->setDisplayingNotPublishedNodes(true);
 
-        /** @var NodesSources|null $source */
-        $source = $nodeSourceRepository->findOneByNodeAndTranslation(
-            $nodeId,
-            $this->managerRegistry->getRepository(Translation::class)->findDefault()
-        );
+        /**
+         * Get all source because if node does not have default traduction we can't find by default traduction.
+         *
+         * @var NodesSources|null $source
+         */
+        $source = $nodeSourceRepository->findByNode(
+            $nodeId
+        )[0] ?? null;
 
         if (null === $source) {
             throw new ResourceNotFoundException();

--- a/lib/RoadizRozierBundle/src/Controller/Node/NodesTagsController.php
+++ b/lib/RoadizRozierBundle/src/Controller/Node/NodesTagsController.php
@@ -50,7 +50,7 @@ final class NodesTagsController extends AbstractController
             ->setDisplayingNotPublishedNodes(true);
 
         /**
-         * Get all source because if node does not have default traduction we can't find by default traduction.
+         * Get all sources because if node does not have default traduction we can't find by default traduction.
          *
          * @var NodesSources|null $source
          */


### PR DESCRIPTION
Use findByNode with setDisplayingAllNodesStatuses(true) and get the first to prevent error on get by default translation when node does not have default translation.