### PR TITLE
fix(hotspot): add size attributes to image

### DIFF
--- a/lib/RoadizRozierBundle/src/Explorer/DocumentExplorerItem.php
+++ b/lib/RoadizRozierBundle/src/Explorer/DocumentExplorerItem.php
@@ -139,6 +139,8 @@ final class DocumentExplorerItem extends AbstractExplorerItem
             $thumbnail80Url = $this->documentUrlGenerator->getUrl();
             $this->documentUrlGenerator->setOptions($previewOptions);
             $editImageUrl = $this->documentUrlGenerator->getUrl();
+            $editImageWidth = $this->document->getImageWidth();
+            $editImageHeight = $this->document->getImageHeight();
         }
 
         $embedFinder = $this->embedFinderFactory?->createForPlatform(
@@ -169,6 +171,8 @@ final class DocumentExplorerItem extends AbstractExplorerItem
             'shortMimeType' => $this->document->getShortMimeType(),
             'thumbnail80' => $thumbnail80Url,
             'editImageUrl' => $editImageUrl,
+            'editImageWidth' => $editImageWidth,
+            'editImageHeight' => $editImageHeight,
             'originalHotspot' => $originalHotspot ?? null,
         ];
     }

--- a/lib/RoadizRozierBundle/src/Form/DocumentEditType.php
+++ b/lib/RoadizRozierBundle/src/Form/DocumentEditType.php
@@ -124,6 +124,8 @@ final class DocumentEditType extends AbstractType
                         'width' => 800,
                         'height' => 800,
                     ])->getUrl(),
+                    'image-width' => $document->getImageWidth(),
+                    'image-height' => $document->getImageHeight(),
                 ],
             ]);
         }

--- a/lib/RoadizRozierBundle/templates/widgets/documentAlignment.html.twig
+++ b/lib/RoadizRozierBundle/templates/widgets/documentAlignment.html.twig
@@ -1,4 +1,13 @@
-{% set imagePath = widget_attributes|split('image-path="')[1]|split('"')[0] %}
+{% macro getWidgetAttribute(widget_attributes, attribute_name) %}
+    {%- set pattern = attribute_name ~ '="' -%}
+    {%- if pattern in widget_attributes -%}
+        {{- widget_attributes|split(pattern)[1]|split('"')[0] -}}
+    {%- endif -%}
+{% endmacro %}
+
+{% set imagePath = _self.getWidgetAttribute(widget_attributes, 'image-path') %}
+{% set imageWidth = _self.getWidgetAttribute(widget_attributes, 'image-width') %}
+{% set imageHeight = _self.getWidgetAttribute(widget_attributes, 'image-height') %}
 
 <document-alignment-widget class="document-alignment-widget" input-base-name="{{ form.vars.full_name }}">
     <div class="document-alignment-widget__image-wrapper">
@@ -11,7 +20,13 @@
             </div>
             <div class="document-alignment-widget__hotspot"></div>
         </div>
-        <img class="document-alignment-widget__image" src="{{ imagePath }}" alt=""/>
+        <img 
+            class="document-alignment-widget__image" 
+            src="{{ imagePath }}" 
+            width="{{ imageWidth }}" 
+            height="{{ imageHeight }}" 
+            alt=""
+        />
     </div>
     <label class="document-alignment-widget__override">
         <input type="checkbox" class="rz-boolean-checkbox" data-on-text="I" data-off-text="O" />

--- a/lib/Rozier/src/Resources/app/containers/DrawerContainer.vue
+++ b/lib/Rozier/src/Resources/app/containers/DrawerContainer.vue
@@ -171,6 +171,8 @@ export default {
             dialog.setAttribute('title', event.document.classname)
             dialog.setAttribute('edit-url', event.document.editItem + '?referer=' + window.location.pathname)
             dialog.setAttribute('image-path', event.document.editImageUrl)
+            dialog.setAttribute('image-width', event.document.editImageWidth)
+            dialog.setAttribute('image-height', event.document.editImageHeight)
             dialog.setAttribute('input-base-name', `${this.drawerName}[${event.index}]`)
 
             if (event.document.originalHotspot) {

--- a/lib/Rozier/src/Resources/app/custom-elements/DocumentAlignmentWidget.js
+++ b/lib/Rozier/src/Resources/app/custom-elements/DocumentAlignmentWidget.js
@@ -10,7 +10,7 @@ function round(value, precision = 3) {
 }
 
 export default class DocumentAlignmentWidget extends HTMLElement {
-    static observedAttributes = ['image-path']
+    static observedAttributes = ['image-path', 'image-width', 'image-height']
 
     // Constants
     static CSS_SELECTORS = {
@@ -111,6 +111,10 @@ export default class DocumentAlignmentWidget extends HTMLElement {
     attributeChangedCallback(name) {
         if (name === 'image-path') {
             this.updateImagePath()
+        } else if (name === 'image-width') {
+            this.updateImageWidth()
+        } else if (name === 'image-height') {
+            this.updateImageHeight()
         }
     }
 
@@ -213,20 +217,50 @@ export default class DocumentAlignmentWidget extends HTMLElement {
         this.pointerDownEvent = null
     }
 
+    getImageElement() {
+        if (!this.imageElement) {
+            this.imageElement = this.querySelector(DocumentAlignmentWidget.CSS_SELECTORS.IMAGE)
+        }
+
+        return this.imageElement
+    }
+
     /**
      * Update the image source when the image-path attribute changes
      */
     updateImagePath() {
-        if (!this.imageElement) {
-            this.imageElement = this.querySelector(DocumentAlignmentWidget.CSS_SELECTORS.IMAGE)
+        const imageElement = this.getImageElement()
 
-            if (!this.imageElement) return
-        }
+        if (!imageElement) return
 
         const imagePath = this.getAttribute('image-path')
 
-        if (imagePath && this.imageElement.src !== imagePath) {
-            this.imageElement.src = imagePath
+        if (imagePath && imageElement.src !== imagePath) {
+            imageElement.src = imagePath
+        }
+    }
+
+    updateImageWidth() {
+        const imageElement = this.getImageElement()
+
+        if (!imageElement) return
+
+        const imageWidth = this.getAttribute('image-width')
+
+        if (imageWidth && imageElement.width !== imageWidth) {
+            imageElement.width = imageWidth
+        }
+    }
+
+    updateImageHeight() {
+        const imageElement = this.getImageElement()
+
+        if (!imageElement) return
+
+        const imageHeight = this.getAttribute('image-height')
+
+        if (imageHeight && imageElement.height !== imageHeight) {
+            imageElement.height = imageHeight
         }
     }
 

--- a/lib/Rozier/src/Resources/app/custom-elements/DocumentEditDialog.js
+++ b/lib/Rozier/src/Resources/app/custom-elements/DocumentEditDialog.js
@@ -189,6 +189,8 @@ export default class DocumentEditDialog extends HTMLElement {
             this.applyInputValues(this.getAttribute('input-base-name'), INPUT_BASE_NAME, document, this.dialog)
 
             widget.setAttribute('image-path', this.getAttribute('image-path'))
+            widget.setAttribute('image-width', this.getAttribute('image-width'))
+            widget.setAttribute('image-height', this.getAttribute('image-height'))
             widget.setAttribute('input-base-name', INPUT_BASE_NAME)
             widget.setAttribute('hotspot-overridable', true)
 


### PR DESCRIPTION
Fix #151 

It adds the size (width/height) attributes to the image tag.
Then we don't need a placeholder; we can just use the native feature for broken images.


<img width="1786" height="624" alt="image" src="https://github.com/user-attachments/assets/b86506b1-6619-488d-859c-3d41649483f3" />
