### PR TITLE
fix: Add `hl.bs.type` highlighting configuration

### DIFF
--- a/lib/RoadizCoreBundle/src/SearchEngine/AbstractSearchHandler.php
+++ b/lib/RoadizCoreBundle/src/SearchEngine/AbstractSearchHandler.php
@@ -17,6 +17,7 @@ abstract class AbstractSearchHandler implements SearchHandlerInterface
 {
     protected LoggerInterface $logger;
     protected int $highlightingFragmentSize = 150;
+    protected string $highlightingBsType = 'WORD';
 
     public function __construct(
         protected readonly ClientRegistry $clientRegistry,
@@ -82,6 +83,7 @@ abstract class AbstractSearchHandler implements SearchHandlerInterface
         $tmp['hl.fragsize'] = $this->getHighlightingFragmentSize();
         $tmp['hl.simple.pre'] = '<span class="solr-highlight">';
         $tmp['hl.simple.post'] = '</span>';
+        $tmp['hl.bs.type'] = $this->getHighlightingBsType();
 
         return $tmp;
     }
@@ -110,6 +112,18 @@ abstract class AbstractSearchHandler implements SearchHandlerInterface
     public function setHighlightingFragmentSize(int $highlightingFragmentSize): AbstractSearchHandler
     {
         $this->highlightingFragmentSize = $highlightingFragmentSize;
+
+        return $this;
+    }
+
+    public function getHighlightingBsType(): string
+    {
+        return $this->highlightingBsType;
+    }
+
+    public function setHighlightingBsType(string $highlightingBsType): AbstractSearchHandler
+    {
+        $this->highlightingBsType = $highlightingBsType;
 
         return $this;
     }

--- a/lib/RoadizCoreBundle/src/SearchEngine/AbstractSearchHandler.php
+++ b/lib/RoadizCoreBundle/src/SearchEngine/AbstractSearchHandler.php
@@ -17,6 +17,12 @@ abstract class AbstractSearchHandler implements SearchHandlerInterface
 {
     protected LoggerInterface $logger;
     protected int $highlightingFragmentSize = 150;
+    /**
+     * Specifies the breakiterator type for dividing the document into passages.
+     * Can be SEPARATOR, SENTENCE, WORD, CHARACTER, LINE, or WHOLE.
+     *
+     * @see https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html
+     */
     protected string $highlightingBsType = 'WORD';
 
     public function __construct(


### PR DESCRIPTION
with the default value `WORD`.