### PR TITLE
fix: Use order by `nodeTypeName` instead of `nt.name`. 

### DIFF
--- a/lib/RoadizRozierBundle/templates/nodes/widgets/node-header.html.twig
+++ b/lib/RoadizRozierBundle/templates/nodes/widgets/node-header.html.twig
@@ -8,7 +8,7 @@
     <th class="mobile-hidden">
         {% trans %}node.type{% endtrans %}
         {% include '@RoadizRozier/includes/column_ordering.html.twig' with {
-            'field': 'nt.name',
+            'field': 'nodeTypeName',
             'filters': filters,
         } only %}
     </th>


### PR DESCRIPTION
The relation between node and node type doesn't exist anymore.
Fixes  #225 