### PR TITLE
fix(tags): Add default translation to tag retrieval

### DIFF
--- a/lib/Rozier/src/AjaxControllers/AjaxTagsController.php
+++ b/lib/Rozier/src/AjaxControllers/AjaxTagsController.php
@@ -91,6 +91,7 @@ class AjaxTagsController extends AbstractAjaxController
         if (count($cleanTagIds)) {
             $tags = $this->getRepository()->findBy([
                 'id' => $cleanTagIds,
+                'translation' => $this->em()->getRepository(Translation::class)->findDefault(),
             ]);
 
             // Sort array by ids given in request

--- a/lib/Rozier/src/Models/TagModel.php
+++ b/lib/Rozier/src/Models/TagModel.php
@@ -17,11 +17,11 @@ final class TagModel implements ModelInterface
 
     public function toArray(): array
     {
-        $firstTrans = $this->tag->getTranslatedTags()->first();
+        $defaultTrans = $this->tag->getTranslatedTagsByDefaultTranslation();
         $name = $this->tag->getTagName();
 
-        if ($firstTrans) {
-            $name = $firstTrans->getName();
+        if ($defaultTrans) {
+            $name = $defaultTrans->getName();
         }
 
         $result = [


### PR DESCRIPTION
Add translation filter to listArrayAction()
Use getTranslatedTagsByDefaultTranslation() function to tagModel->toArray()