### PR TITLE
feat: add RzMarkdownEditor

### DIFF
--- a/lib/RoadizRozierBundle/templates/forms.html.twig
+++ b/lib/RoadizRozierBundle/templates/forms.html.twig
@@ -263,7 +263,7 @@
         </ul>
     </nav>
     <div class="markdown-editor-count"><span class="count-current"></span>/<span class="count-limit"></span></div>
-</rz->
+</rz-markdown-editor>
 {% endblock markdown_widget %}
 
 

--- a/lib/RoadizRozierBundle/templates/forms.html.twig
+++ b/lib/RoadizRozierBundle/templates/forms.html.twig
@@ -52,9 +52,9 @@
 {%- endblock data_list_text_widget -%}
 
 {% block markdown_widget %}
-<div class="markdown-editor-wrapper">
+<rz-markdown-editor>
     {# just let the textarea widget render the select tag #}
-    <textarea {{ block('widget_attributes') }} data-rz-markdowneditor>{{- value -}}</textarea>
+    <textarea {{ block('widget_attributes') }}>{{- value -}}</textarea>
     <nav class="markdown-editor-navbar">
         <ul class="markdown-editor-navbar-nav">
             {% if attr.allow_h2 %}
@@ -263,7 +263,7 @@
         </ul>
     </nav>
     <div class="markdown-editor-count"><span class="count-current"></span>/<span class="count-limit"></span></div>
-</div>
+</rz->
 {% endblock markdown_widget %}
 
 

--- a/lib/Rozier/app/Lazyload.js
+++ b/lib/Rozier/app/Lazyload.js
@@ -6,7 +6,6 @@ import StackNodeTree from './widgets/StackNodeTree'
 import SettingsSaveButtons from './widgets/SettingsSaveButtons'
 import NodeStatuses from './widgets/NodeStatuses'
 import YamlEditor from './widgets/YamlEditor'
-import MarkdownEditor from './widgets/MarkdownEditor'
 import JsonEditor from './widgets/JsonEditor'
 import CssEditor from './widgets/CssEditor'
 import LeafletGeotagField from './widgets/LeafletGeotagField'
@@ -25,7 +24,6 @@ export default class Lazyload {
         this.attributeValuesPosition = null
         this.customFormFieldsPosition = null
         this.settingsSaveButtons = null
-        this.markdownEditors = []
         this.jsonEditors = []
         this.cssEditors = []
         this.yamlEditors = []
@@ -199,9 +197,6 @@ export default class Lazyload {
     }
 
     refreshCodemirrorEditor() {
-        for (let editor of this.markdownEditors) {
-            editor.forceEditorUpdate()
-        }
         for (let editor of this.yamlEditors) {
             editor.forceEditorUpdate()
         }
@@ -214,9 +209,6 @@ export default class Lazyload {
     }
 
     destroyCodemirrorEditor() {
-        for (let editor of this.markdownEditors) {
-            editor.destroy()
-        }
         for (let editor of this.yamlEditors) {
             editor.destroy()
         }
@@ -298,7 +290,6 @@ export default class Lazyload {
             this.settingsSaveButtons,
         ])
         this.bindAjaxLink()
-        this.markdownEditors = []
         this.jsonEditors = []
         this.cssEditors = []
         this.yamlEditors = []
@@ -315,7 +306,6 @@ export default class Lazyload {
         this.settingsSaveButtons = new SettingsSaveButtons()
 
         // Codemirror
-        this.initMarkdownEditors()
         this.initJsonEditors()
         this.initCssEditors()
         this.initYamlEditors()
@@ -359,7 +349,6 @@ export default class Lazyload {
                  */
                 after_add: (collection, element) => {
                     const el = element[0]
-                    this.initMarkdownEditors(el)
                     this.initJsonEditors(el)
                     this.initCssEditors(el)
                     this.initYamlEditors(el)
@@ -375,32 +364,6 @@ export default class Lazyload {
                     return true
                 },
             })
-        }
-    }
-
-    /**
-     * @param {HTMLElement|undefined} scope
-     */
-    initMarkdownEditors(scope) {
-        // Init markdown-preview
-        let textareasMarkdown = []
-        if (scope) {
-            textareasMarkdown = scope.querySelectorAll(
-                'textarea[data-rz-markdowneditor]',
-            )
-        } else {
-            textareasMarkdown = document.querySelectorAll(
-                'textarea[data-rz-markdowneditor]',
-            )
-        }
-        let editorCount = textareasMarkdown.length
-
-        if (editorCount) {
-            for (let i = 0; i < editorCount; i++) {
-                this.markdownEditors.push(
-                    new MarkdownEditor(textareasMarkdown[i], i),
-                )
-            }
         }
     }
 

--- a/lib/Rozier/app/custom-elements/RzMarkdownEditor.js
+++ b/lib/Rozier/app/custom-elements/RzMarkdownEditor.js
@@ -2,16 +2,16 @@ import { addClass, stripTags } from '../utils/plugins'
 import markdownit from 'markdown-it'
 import markdownItFootnote from 'markdown-it-footnote'
 
-export default class MarkdownEditor {
+export default class MarkdownEditor extends HTMLElement {
     /**
      * @param {HTMLTextAreaElement} textarea
      * @param index
      */
-    constructor(textarea, index) {
+    connectedCallback() {
         this.markdownit = new markdownit()
         this.markdownit.use(markdownItFootnote)
 
-        this.textarea = textarea
+        this.textarea = this.querySelector('textarea')
         this.usePreview = false
 
         this.editor = window.CodeMirror.fromTextArea(this.textarea, {
@@ -51,7 +51,6 @@ export default class MarkdownEditor {
         // Selectors
         this.cont = this.textarea.closest('.uk-form-row')
         this.parentForm = this.textarea.closest('form')
-        this.index = index
         this.buttonCode = null
         this.buttonPreview = null
         this.buttonTranslateAssistant = null
@@ -81,6 +80,10 @@ export default class MarkdownEditor {
 
         // Methods
         this.init()
+    }
+
+    disconnectedCallback() {
+        this.destroy()
     }
 
     /**

--- a/lib/Rozier/app/custom-elements/RzMarkdownEditor.ts
+++ b/lib/Rozier/app/custom-elements/RzMarkdownEditor.ts
@@ -1,20 +1,76 @@
-import { addClass, stripTags } from '../utils/plugins'
+import { addClass, stripTags } from '~/utils/plugins'
 import markdownit from 'markdown-it'
 import markdownItFootnote from 'markdown-it-footnote'
+import CodeMirror from 'codemirror'
+import 'codemirror/mode/gfm/gfm'
+import type {
+    Editor,
+    EditorConfiguration,
+    EditorFromTextArea,
+} from 'codemirror'
 
-export default class MarkdownEditor extends HTMLElement {
-    /**
-     * @param {HTMLTextAreaElement} textarea
-     * @param index
-     */
+interface TranslationResponse {
+    originalText: string
+    translatedText: string
+    sourceLang: string
+    targetLang: string
+}
+
+interface DocumentUploadResponse {
+    success: boolean
+    document: {
+        name: string
+        url: string
+    }
+}
+
+type ExtendedEditorConfiguration = EditorConfiguration & {
+    enterMode?: string
+    styleActiveLine?: boolean
+}
+
+export default class RzMarkdownEditor extends HTMLElement {
+    markdownit!: markdownit
+    textarea!: HTMLTextAreaElement
+    usePreview: boolean = false
+    editor!: EditorFromTextArea
+    cont: HTMLElement | null = null
+    parentForm: HTMLFormElement | null = null
+    buttonCode: NodeListOf<HTMLElement> | null = null
+    buttonPreview: NodeListOf<HTMLElement> | null = null
+    buttonTranslateAssistant: NodeListOf<HTMLElement> | null = null
+    buttonTranslateAssistantRephrase: NodeListOf<HTMLElement> | null = null
+    buttonFullscreen: NodeListOf<HTMLElement> | null = null
+    count: NodeListOf<HTMLElement> | null = null
+    countCurrent: NodeListOf<HTMLElement> | null = null
+    limit: boolean = false
+    countMinLimit: number = 0
+    countMaxLimit: number = 0
+    countMaxLimitText: NodeListOf<HTMLElement> | null = null
+    countAlertActive: boolean = false
+    fullscreenActive: boolean = false
+    $editor!: HTMLElement
+    buttons: NodeListOf<HTMLElement> | null = null
+    content: NodeListOf<HTMLElement> | null = null
+    tabs!: HTMLDivElement
+    previewContainer!: HTMLElement
+    preview!: HTMLDivElement
+    refreshPreviewTimeout: number | null = null
+    index: number = 0
+
     connectedCallback() {
         this.markdownit = new markdownit()
         this.markdownit.use(markdownItFootnote)
 
-        this.textarea = this.querySelector('textarea')
+        const textarea = this.querySelector<HTMLTextAreaElement>('textarea')
+        if (!textarea) {
+            console.error('No textarea found in RzMarkdownEditor')
+            return
+        }
+        this.textarea = textarea
         this.usePreview = false
 
-        this.editor = window.CodeMirror.fromTextArea(this.textarea, {
+        const editorConfig: ExtendedEditorConfiguration = {
             mode: 'gfm',
             lineNumbers: false,
             tabSize: 4,
@@ -31,19 +87,21 @@ export default class MarkdownEditor extends HTMLElement {
             readOnly:
                 this.textarea.hasAttribute('disabled') &&
                 this.textarea.getAttribute('disabled') === 'disabled',
-        })
+        }
+
+        this.editor = CodeMirror.fromTextArea(this.textarea, editorConfig)
 
         this.editor.addKeyMap({
-            'Ctrl-B': (cm) => {
+            'Ctrl-B': (cm: Editor) => {
                 cm.replaceSelections(this.boldSelections())
             },
-            'Ctrl-I': (cm) => {
+            'Ctrl-I': (cm: Editor) => {
                 cm.replaceSelections(this.italicSelections())
             },
-            'Cmd-B': (cm) => {
+            'Cmd-B': (cm: Editor) => {
                 cm.replaceSelections(this.boldSelections())
             },
-            'Cmd-I': (cm) => {
+            'Cmd-I': (cm: Editor) => {
                 cm.replaceSelections(this.italicSelections())
             },
         })
@@ -51,20 +109,8 @@ export default class MarkdownEditor extends HTMLElement {
         // Selectors
         this.cont = this.textarea.closest('.uk-form-row')
         this.parentForm = this.textarea.closest('form')
-        this.buttonCode = null
-        this.buttonPreview = null
-        this.buttonTranslateAssistant = null
-        this.buttonTranslateAssistantRephrase = null
-        this.buttonFullscreen = null
-        this.count = null
-        this.countCurrent = null
-        this.limit = 0
-        this.countMinLimit = 0
-        this.countMaxLimit = 0
-        this.countMaxLimitText = null
-        this.countAlertActive = false
-        this.fullscreenActive = false
 
+        // Bind methods
         this.closePreview = this.closePreview.bind(this)
         this.textareaChange = this.textareaChange.bind(this)
         this.textareaFocus = this.textareaFocus.bind(this)
@@ -86,10 +132,6 @@ export default class MarkdownEditor extends HTMLElement {
         this.destroy()
     }
 
-    /**
-     * Init
-     * @return {[type]} [description]
-     */
     init() {
         this.editor.on('change', this.textareaChange)
 
@@ -97,7 +139,13 @@ export default class MarkdownEditor extends HTMLElement {
             return
         }
 
-        this.$editor = this.cont.querySelector('.CodeMirror')
+        const editorElement =
+            this.cont.querySelector<HTMLElement>('.CodeMirror')
+        if (!editorElement) {
+            console.error('No CodeMirror element found')
+            return
+        }
+        this.$editor = editorElement
 
         this.cont.classList.add('markdown-editor')
         if (this.editor.getOption('readOnly') === true) {
@@ -106,6 +154,7 @@ export default class MarkdownEditor extends HTMLElement {
         this.buttons = this.cont.querySelectorAll(
             '[data-markdowneditor-button]',
         )
+
         // Selectors
         this.content = this.cont.querySelectorAll('.markdown-editor-content')
         this.buttonCode = this.cont.querySelectorAll(
@@ -128,35 +177,19 @@ export default class MarkdownEditor extends HTMLElement {
         )
 
         // Store markdown index into datas
-        const buttonsCode = this.cont.querySelectorAll(
-            '.markdown-editor-button-code',
+        this.setDataIndex(
+            this.cont.querySelectorAll('.markdown-editor-button-code'),
         )
-        buttonsCode.forEach((button) => {
-            button.setAttribute('data-index', this.index)
-        })
-        const buttonPreview = this.cont.querySelectorAll(
-            '.markdown-editor-button-preview',
+        this.setDataIndex(
+            this.cont.querySelectorAll('.markdown-editor-button-preview'),
         )
-        buttonPreview.forEach((button) => {
-            button.setAttribute('data-index', this.index)
-        })
-        const buttonFullscreen = this.cont.querySelectorAll(
-            '.markdown-editor-button-fullscreen',
+        this.setDataIndex(
+            this.cont.querySelectorAll('.markdown-editor-button-fullscreen'),
         )
-        buttonFullscreen.forEach((button) => {
-            button.setAttribute('data-index', this.index)
-        })
-        const mdTextarea = this.cont.querySelectorAll('.markdown_textarea')
-        mdTextarea.forEach((textarea) => {
-            textarea.setAttribute('data-index', this.index)
-        })
-        this.$editor.setAttribute('data-index', this.index)
-        this.buttonTranslateAssistant.forEach((button) => {
-            button.setAttribute('data-index', this.index)
-        })
-        this.buttonTranslateAssistantRephrase.forEach((button) => {
-            button.setAttribute('data-index', this.index)
-        })
+        this.setDataIndex(this.cont.querySelectorAll('.markdown_textarea'))
+        this.setDataIndex(this.buttonTranslateAssistant)
+        this.setDataIndex(this.buttonTranslateAssistantRephrase)
+        this.$editor.setAttribute('data-index', String(this.index))
 
         /*
          * Create preview tab.
@@ -165,9 +198,15 @@ export default class MarkdownEditor extends HTMLElement {
         editorTabs.classList.add('markdown-editor-tabs')
         this.$editor.before(editorTabs)
         this.tabs = editorTabs
-        this.previewContainer = document.getElementById(
+
+        const previewContainer = document.getElementById(
             'codemirror-preview-containers',
         )
+        if (!previewContainer) {
+            console.error('No preview container found')
+            return
+        }
+        this.previewContainer = previewContainer
 
         const editorPreview = document.createElement('div')
         editorPreview.classList.add('markdown-editor-preview')
@@ -185,7 +224,7 @@ export default class MarkdownEditor extends HTMLElement {
         ) {
             this.limit = true
             this.countMaxLimit = parseInt(
-                this.textarea.getAttribute('data-max-length'),
+                this.textarea.getAttribute('data-max-length') || '0',
             )
 
             if (
@@ -193,11 +232,11 @@ export default class MarkdownEditor extends HTMLElement {
                 this.countMaxLimitText.length &&
                 this.count.length
             ) {
-                this.countCurrent[0].innerHTML = stripTags(
-                    this.editor.getValue(),
-                ).length
+                this.countCurrent[0].innerHTML = String(
+                    stripTags(this.editor.getValue()).length,
+                )
                 this.countMaxLimitText[0].innerHTML =
-                    this.textarea.getAttribute('data-max-length')
+                    this.textarea.getAttribute('data-max-length') || ''
                 this.count[0].style.display = 'block'
             }
         }
@@ -208,7 +247,7 @@ export default class MarkdownEditor extends HTMLElement {
         ) {
             this.limit = true
             this.countMinLimit = parseInt(
-                this.textarea.getAttribute('data-min-length'),
+                this.textarea.getAttribute('data-min-length') || '0',
             )
         }
 
@@ -219,8 +258,8 @@ export default class MarkdownEditor extends HTMLElement {
             this.textarea.getAttribute('data-max-length') === ''
         ) {
             this.limit = false
-            this.countMaxLimit = null
-            this.countAlertActive = null
+            this.countMaxLimit = 0
+            this.countAlertActive = false
         }
 
         this.fullscreenActive = false
@@ -235,7 +274,9 @@ export default class MarkdownEditor extends HTMLElement {
             ) {
                 this.countAlertActive = true
                 addClass(this.cont, 'content-limit')
-            } else this.countAlertActive = false
+            } else {
+                this.countAlertActive = false
+            }
         }
 
         this.editor.on('change', this.textareaChange)
@@ -268,18 +309,27 @@ export default class MarkdownEditor extends HTMLElement {
         })
     }
 
-    async onDropFile(editor, event) {
-        event.preventDefault(event)
+    setDataIndex(elements: NodeListOf<Element> | null) {
+        if (!elements) return
+        elements.forEach((element) => {
+            element.setAttribute('data-index', String(this.index))
+        })
+    }
+
+    async onDropFile(editor: Editor, event: DragEvent): Promise<void> {
+        event.preventDefault()
+
+        if (!event.dataTransfer?.files) return
 
         for (let i = 0; i < event.dataTransfer.files.length; i++) {
             window.dispatchEvent(new CustomEvent('requestLoaderShow'))
-            let file = event.dataTransfer.files[i]
-            let formData = new FormData()
-            formData.append('_token', window.RozierConfig.ajaxToken)
+            const file = event.dataTransfer.files[i]
+            const formData = new FormData()
+            formData.append('_token', window.RozierConfig.ajaxToken || '')
             formData.append('form[attachment]', file)
 
             const response = await fetch(
-                window.RozierConfig.routes.documentsUploadPage,
+                window.RozierConfig.routes?.documentsUploadPage || '',
                 {
                     method: 'POST',
                     headers: {
@@ -290,6 +340,7 @@ export default class MarkdownEditor extends HTMLElement {
                     body: formData,
                 },
             )
+
             if (!response.ok) {
                 const data = await response.json()
                 if (data.errors) {
@@ -310,13 +361,12 @@ export default class MarkdownEditor extends HTMLElement {
         }
     }
 
-    onDropFileUploaded(editor, data) {
+    onDropFileUploaded(editor: Editor, data: DocumentUploadResponse) {
         window.dispatchEvent(new CustomEvent('requestLoaderHide'))
 
         if (data.success === true) {
-            let mark =
+            const mark =
                 '![' + data.document.name + '](' + data.document.url + ')'
-
             editor.replaceSelection(mark)
         }
     }
@@ -331,15 +381,12 @@ export default class MarkdownEditor extends HTMLElement {
         }
     }
 
-    /**
-     * @param {Event} event
-     */
-    buttonClick(event) {
+    buttonClick(event: Event) {
         if (this.editor.getOption('readOnly') === true) {
-            return false
+            return
         }
-        let $button = event.currentTarget
-        let sel = this.editor.getSelections()
+        const $button = event.currentTarget as HTMLElement
+        const sel = this.editor.getSelections()
 
         if (sel.length > 0) {
             switch ($button.getAttribute('data-markdowneditor-button')) {
@@ -399,138 +446,82 @@ export default class MarkdownEditor extends HTMLElement {
         }
     }
 
-    backSelections(selections) {
-        for (let i in selections) {
-            selections[i] = '   \n'
-        }
-        return selections
+    backSelections(selections: string[]): string[] {
+        return selections.map(() => '   \n')
     }
 
-    hrSelections(selections) {
-        for (let i in selections) {
-            selections[i] = '\n\n---\n\n'
-        }
-        return selections
+    hrSelections(selections: string[]): string[] {
+        return selections.map(() => '\n\n---\n\n')
     }
 
-    nbspSelections(selections) {
-        for (let i in selections) {
-            selections[i] = ' '
-        }
-        return selections
+    nbspSelections(selections: string[]): string[] {
+        return selections.map(() => ' ')
     }
 
-    nbHyphenSelections(selections) {
-        for (let i in selections) {
-            selections[i] = '‑'
-        }
-        return selections
+    nbHyphenSelections(selections: string[]): string[] {
+        return selections.map(() => '‑')
     }
 
-    listUlSelections(selections) {
-        for (let i in selections) {
-            selections[i] = '\n\n* ' + selections[i] + '\n\n'
-        }
-        return selections
+    listUlSelections(selections: string[]): string[] {
+        return selections.map((sel) => '\n\n* ' + sel + '\n\n')
     }
 
-    linkSelections(selections) {
-        for (let i in selections) {
-            selections[i] = '[' + selections[i] + '](http://)'
-        }
-        return selections
+    linkSelections(selections: string[]): string[] {
+        return selections.map((sel) => '[' + sel + '](http://)')
     }
 
-    imageSelections(selections) {
+    imageSelections(selections?: string[]): string[] {
         if (!selections) {
             selections = this.editor.getSelections()
         }
-        for (let i in selections) {
-            selections[i] = '![' + selections[i] + '](/files/)'
-        }
-        return selections
+        return selections.map((sel) => '![' + sel + '](/files/)')
     }
 
-    boldSelections(selections) {
+    boldSelections(selections?: string[]): string[] {
         if (!selections) {
             selections = this.editor.getSelections()
         }
-
-        for (let i in selections) {
-            selections[i] = '**' + selections[i] + '**'
-        }
-
-        return selections
+        return selections.map((sel) => '**' + sel + '**')
     }
 
-    italicSelections(selections) {
+    italicSelections(selections?: string[]): string[] {
         if (!selections) {
             selections = this.editor.getSelections()
         }
-
-        for (let i in selections) {
-            selections[i] = '*' + selections[i] + '*'
-        }
-
-        return selections
+        return selections.map((sel) => '*' + sel + '*')
     }
 
-    h2Selections(selections) {
-        for (let i in selections) {
-            selections[i] = '\n## ' + selections[i] + '\n'
-        }
-
-        return selections
+    h2Selections(selections: string[]): string[] {
+        return selections.map((sel) => '\n## ' + sel + '\n')
     }
 
-    h3Selections(selections) {
-        for (let i in selections) {
-            selections[i] = '\n### ' + selections[i] + '\n'
-        }
-
-        return selections
+    h3Selections(selections: string[]): string[] {
+        return selections.map((sel) => '\n### ' + sel + '\n')
     }
 
-    h4Selections(selections) {
-        for (let i in selections) {
-            selections[i] = '\n#### ' + selections[i] + '\n'
-        }
-
-        return selections
+    h4Selections(selections: string[]): string[] {
+        return selections.map((sel) => '\n#### ' + sel + '\n')
     }
 
-    h5Selections(selections) {
-        for (let i in selections) {
-            selections[i] = '\n##### ' + selections[i] + '\n'
-        }
-
-        return selections
+    h5Selections(selections: string[]): string[] {
+        return selections.map((sel) => '\n##### ' + sel + '\n')
     }
 
-    h6Selections(selections) {
-        for (let i in selections) {
-            selections[i] = '\n###### ' + selections[i] + '\n'
-        }
-
-        return selections
+    h6Selections(selections: string[]): string[] {
+        return selections.map((sel) => '\n###### ' + sel + '\n')
     }
 
-    blockquoteSelections(selections) {
-        for (let i in selections) {
-            selections[i] = '\n> ' + selections[i] + '\n'
-        }
-
-        return selections
+    blockquoteSelections(selections: string[]): string[] {
+        return selections.map((sel) => '\n> ' + sel + '\n')
     }
 
-    /**
-     * Textarea change
-     */
     textareaChange() {
         this.editor.save()
 
         if (this.usePreview) {
-            window.cancelAnimationFrame(this.refreshPreviewTimeout)
+            if (this.refreshPreviewTimeout !== null) {
+                window.cancelAnimationFrame(this.refreshPreviewTimeout)
+            }
             this.refreshPreviewTimeout = window.requestAnimationFrame(() => {
                 this.preview.innerHTML = this.markdownit.render(
                     this.editor.getValue(),
@@ -540,25 +531,27 @@ export default class MarkdownEditor extends HTMLElement {
 
         if (this.limit) {
             window.requestAnimationFrame(() => {
-                let textareaVal = this.editor.getValue()
-                let textareaValStripped = stripTags(textareaVal)
-                let textareaValLength = textareaValStripped.length
+                const textareaVal = this.editor.getValue()
+                const textareaValStripped = stripTags(textareaVal)
+                const textareaValLength = textareaValStripped.length
 
-                this.countCurrent[0].innerHTML = textareaValLength
+                if (this.countCurrent && this.countCurrent.length > 0) {
+                    this.countCurrent[0].innerHTML = String(textareaValLength)
+                }
 
                 if (textareaValLength > this.countMaxLimit) {
                     if (!this.countAlertActive) {
-                        this.cont.classList.add('content-limit')
+                        this.cont?.classList.add('content-limit')
                         this.countAlertActive = true
                     }
                 } else if (textareaValLength < this.countMinLimit) {
                     if (!this.countAlertActive) {
-                        this.cont.classList.add('content-limit')
+                        this.cont?.classList.add('content-limit')
                         this.countAlertActive = true
                     }
                 } else {
                     if (this.countAlertActive) {
-                        this.cont.classList.remove('content-limit')
+                        this.cont?.classList.remove('content-limit')
                         this.countAlertActive = false
                     }
                 }
@@ -566,31 +559,22 @@ export default class MarkdownEditor extends HTMLElement {
         }
     }
 
-    /**
-     * Textarea focus
-     */
     textareaFocus() {
-        this.cont.classList.add('form-col-focus')
+        this.cont?.classList.add('form-col-focus')
     }
 
-    /**
-     * Textarea focus out
-     */
     textareaBlur() {
-        this.cont.classList.remove('form-col-focus')
+        this.cont?.classList.remove('form-col-focus')
     }
 
-    /**
-     * Button preview click
-     */
-    buttonPreviewClick(e) {
+    buttonPreviewClick(e: Event) {
         e.preventDefault()
 
         if (this.usePreview) {
             this.closePreview()
         } else {
             this.usePreview = true
-            this.buttonPreview.forEach((button) => {
+            this.buttonPreview?.forEach((button) => {
                 button.classList.add('uk-active', 'active')
             })
             this.preview.classList.add('active')
@@ -604,10 +588,7 @@ export default class MarkdownEditor extends HTMLElement {
         }
     }
 
-    /**
-     *
-     */
-    closePreview(e) {
+    closePreview(e?: KeyboardEvent) {
         if (e) {
             if (e.keyCode === 27) {
                 e.preventDefault()
@@ -618,7 +599,7 @@ export default class MarkdownEditor extends HTMLElement {
 
         window.removeEventListener('keyup', this.closePreview)
         this.usePreview = false
-        this.buttonPreview.forEach((button) => {
+        this.buttonPreview?.forEach((button) => {
             button.classList.remove('uk-active', 'active')
         })
         this.preview.classList.remove('active')
@@ -628,23 +609,17 @@ export default class MarkdownEditor extends HTMLElement {
         this.preview.remove()
     }
 
-    /**
-     * Window resize callback
-     * @return {[type]} [description]
-     */
-    resize() {}
+    resize() {
+        // Reserved for future use
+    }
 
-    /**
-     * Button translate assistant click
-     */
-    async buttonTranslateAssistantClick(e) {
+    async buttonTranslateAssistantClick(e: Event): Promise<void> {
         e.preventDefault()
 
         const text = this.editor.getValue()
-        const targetLang = e.currentTarget.getAttribute('data-translate-locale')
-        const translatePath = e.currentTarget.getAttribute(
-            'data-translate-path',
-        )
+        const button = e.currentTarget as HTMLElement
+        const targetLang = button.getAttribute('data-translate-locale')
+        const translatePath = button.getAttribute('data-translate-path')
 
         if (!translatePath || !text || text.length === 0) {
             return
@@ -657,27 +632,25 @@ export default class MarkdownEditor extends HTMLElement {
             },
             body: new URLSearchParams({
                 text: text,
-                targetLang: targetLang,
+                targetLang: targetLang || '',
             }),
         })
+
         if (!response.ok) {
             throw new Error(`Response status: ${response.status}`)
         }
-        /** @type {{ originalText: string, translatedText: string ,sourceLang: string, targetLang: string }} */
-        const result = await response.json()
 
+        const result: TranslationResponse = await response.json()
         this.editor.setValue(result.translatedText)
     }
 
-    /**
-     * Button rephrase assistant click
-     */
-    async buttonTranslateAssistantRephraseClick(e) {
+    async buttonTranslateAssistantRephraseClick(e: Event): Promise<void> {
         e.preventDefault()
 
         const text = this.editor.getValue()
-        const targetLang = e.currentTarget.getAttribute('data-translate-locale')
-        const rephrasePath = e.currentTarget.getAttribute('data-translate-path')
+        const button = e.currentTarget as HTMLElement
+        const targetLang = button.getAttribute('data-translate-locale')
+        const rephrasePath = button.getAttribute('data-translate-path')
 
         if (!rephrasePath || !text || text.length === 0) {
             return
@@ -690,16 +663,15 @@ export default class MarkdownEditor extends HTMLElement {
             },
             body: new URLSearchParams({
                 text: text,
-                targetLang: targetLang,
+                targetLang: targetLang || '',
             }),
         })
+
         if (!response.ok) {
             throw new Error(`Response status: ${response.status}`)
         }
 
-        /** @type {{ originalText: string, translatedText: string ,sourceLang: string, targetLang: string }} */
-        const result = await response.json()
-
+        const result: TranslationResponse = await response.json()
         this.editor.setValue(result.translatedText)
     }
 }

--- a/lib/Rozier/package.json
+++ b/lib/Rozier/package.json
@@ -43,6 +43,7 @@
     "@storybook/addon-docs": "^9.1.8",
     "@storybook/html-vite": "^9.1.8",
     "@stylistic/eslint-plugin": "^5.4.0",
+    "@types/codemirror": "^5.60.17",
     "@types/node": "^24.0.8",
     "@typescript-eslint/eslint-plugin": "^8.35.1",
     "@typescript-eslint/parser": "^8.35.1",

--- a/lib/Rozier/pnpm-lock.yaml
+++ b/lib/Rozier/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@stylistic/eslint-plugin':
         specifier: ^5.4.0
         version: 5.4.0(eslint@9.36.0(jiti@2.6.1))
+      '@types/codemirror':
+        specifier: ^5.60.17
+        version: 5.60.17
       '@types/node':
         specifier: ^24.0.8
         version: 24.6.2
@@ -720,6 +723,9 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/codemirror@5.60.17':
+    resolution: {integrity: sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -743,6 +749,9 @@ packages:
 
   '@types/tar@6.1.13':
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
+
+  '@types/tern@0.23.9':
+    resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -2751,6 +2760,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/codemirror@5.60.17':
+    dependencies:
+      '@types/tern': 0.23.9
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/eslint@9.6.1':
@@ -2777,6 +2790,10 @@ snapshots:
     dependencies:
       '@types/node': 24.6.2
       minipass: 4.2.8
+
+  '@types/tern@0.23.9':
+    dependencies:
+      '@types/estree': 1.0.8
 
   '@types/yauzl@2.10.3':
     dependencies:


### PR DESCRIPTION
- moves the legacy MarkdownEditor class to the new RzMarkdownEditor custom element
- rewrites the JS class to TS
- removes the class initialization from LazyLoad.js because all the lifecycle is handled internally