### PR TITLE
fix(rozier): update newParentId assignment logic to avoid sending "null" or "undefined" query-string

### DIFF
--- a/lib/Rozier/app/Rozier.js
+++ b/lib/Rozier/app/Rozier.js
@@ -786,7 +786,10 @@ export default class Rozier {
         const postData = {
             csrfToken: window.RozierConfig.ajaxToken,
             id: nodeId,
-            newParentId: parentNodeId,
+        }
+
+        if (parentNodeId) {
+            postData.newParentId = parentNodeId
         }
 
         /*
@@ -879,7 +882,7 @@ export default class Rozier {
          * set parentTagId to NULL
          */
         if (isNaN(parentTagId)) {
-            parentTagId = null
+            parentTagId = undefined
         }
 
         /*
@@ -896,7 +899,10 @@ export default class Rozier {
         let postData = {
             csrfToken: window.RozierConfig.ajaxToken,
             id: tagId,
-            newParentId: parentTagId,
+        }
+
+        if (parentTagId) {
+            postData.newParentId = parentTagId
         }
 
         /*
@@ -1013,7 +1019,10 @@ export default class Rozier {
         let postData = {
             csrfToken: window.RozierConfig.ajaxToken,
             id: folderId,
-            newParentId: parentFolderId,
+        }
+
+        if (parentFolderId) {
+            postData.newParentId = parentFolderId
         }
 
         /*

--- a/lib/Rozier/app/custom-elements/NodeTreeContextualMenu.js
+++ b/lib/Rozier/app/custom-elements/NodeTreeContextualMenu.js
@@ -274,11 +274,9 @@ export default class NodeTreeContextualMenu extends HTMLElement {
          * When dropping to root
          * set parentNodeId to NULL
          */
-        if (isNaN(parentNodeId)) {
-            parentNodeId = null
+        if (parentNodeId && !isNaN(parentNodeId)) {
+            postData.newParentId = parentNodeId
         }
-
-        postData.newParentId = parentNodeId
 
         try {
             await this.postNodeUpdate(this.editPositionPath, postData)


### PR DESCRIPTION
Fixes #419