### PR TITLE
feat(seo): replace title-duplicating meta-description fallback with an explicit node-type field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -210,7 +210,8 @@
             "RZ\\Roadiz\\Tests\\": "lib/Models/tests/",
             "RZ\\Roadiz\\CoreBundle\\Tests\\": "lib/RoadizCoreBundle/tests/",
             "RZ\\Roadiz\\Documents\\Tests\\": "lib/Documents/tests/",
-            "RZ\\Roadiz\\EntityGenerator\\Tests\\": "lib/EntityGenerator/tests/"
+            "RZ\\Roadiz\\EntityGenerator\\Tests\\": "lib/EntityGenerator/tests/",
+            "RZ\\Roadiz\\Markdown\\Tests\\": "lib/Markdown/tests/"
         }
     },
     "replace": {

--- a/config/node_types/article.yaml
+++ b/config/node_types/article.yaml
@@ -13,6 +13,7 @@ fields:
         description: 'Your content'
         label: 'Your content'
         type: markdown
+        metaDescriptionFallback: true
     -
         name: images
         universal: true

--- a/config/node_types/page.yaml
+++ b/config/node_types/page.yaml
@@ -33,6 +33,7 @@ fields:
             allow_translate_assistant_translate: true
             allow_translate_assistant_rephrase: true
         type: markdown
+        metaDescriptionFallback: true
     -
         name: color
         universal: true

--- a/docs/developer/api/web_response.md
+++ b/docs/developer/api/web_response.md
@@ -71,7 +71,7 @@ to populate all data during the `asyncData()` routine in `_.vue` page
         "matomoSiteId": null,
         "siteName": "Roadiz dev website",
         "metaTitle": "Contact – Roadiz dev website",
-        "metaDescription": "Contact, Roadiz dev website",
+        "metaDescription": null,
         "policyUrl": null,
         "mainColor": null,
         "facebookUrl": null,
@@ -625,7 +625,7 @@ Then, the following resource will be exposed:
         "matomoSiteId": null,
         "siteName": "Roadiz dev website",
         "metaTitle": "Contact – Roadiz dev website",
-        "metaDescription": "Contact, Roadiz dev website",
+        "metaDescription": null,
         "homePageUrl": "/",
         "shareImage": null
     },

--- a/docs/developer/nodes-system/node_type_fields.md
+++ b/docs/developer/nodes-system/node_type_fields.md
@@ -96,6 +96,27 @@ If you need a field to hold exactly the same data for all translations, you can 
 
 It will duplicate data at each save time from the default translation to others. It will also hide the edit field from non-default translations to avoid confusion.
 
+## Meta-description fallback field
+
+The **meta-description** stored on `NodesSources` feeds the SEO `<meta name="description">` tag exposed through the `WebResponse` *head*. When an editor leaves it empty, Roadiz no longer fabricates a description from the node title and site name — an irrelevant, duplicated description hurts SEO more than an absent one, so the head now exposes `null` instead.
+
+Instead, you can designate **one** text field per node-type as the meta-description fallback with the `metaDescriptionFallback` flag. When the stored meta-description is empty, the generated `getMetaDescriptionOrFallback()` method on your *NSEntity* returns this field's content instead. The raw `getMetaDescription()` getter is left untouched — so the back-office SEO form keeps showing (and saving) only the value the editor actually typed, never the computed fallback:
+
+```yaml
+fields:
+    - name: excerpt
+      label: Excerpt
+      type: markdown
+      metaDescriptionFallback: true
+```
+
+Constraints, enforced when node-types are loaded:
+
+- **At most one** field per node-type can be flagged.
+- The flagged field must be a `string`, `text`, or `markdown` type.
+
+The fallback value is then stripped of Markdown, trimmed of control characters, and truncated to 160 characters before being exposed in the head. A candidate shorter than 20 characters is discarded (the head exposes `null`), to avoid thin or duplicated descriptions.
+
 ## YAML field
 
 When you use the YAML field type, you get an additional method to return your code already parsed. If your field is named `data`, your methods will be generated in your *NSEntity* as `getData()` and `getDataAsObject()`.

--- a/lib/EntityGenerator/src/EntityGenerator.php
+++ b/lib/EntityGenerator/src/EntityGenerator.php
@@ -326,6 +326,48 @@ final class EntityGenerator implements EntityGeneratorInterface
             ->setBody('return \'['.$this->nodeTypeClassLocator->getSourceEntityClassName($this->nodeType).'] \' . parent::__toString();')
         ;
 
+        $this->addMetaDescriptionFallbackMethod($classType);
+
         return $this;
+    }
+
+    /**
+     * Override getMetaDescriptionOrFallback to fall back on a text field flagged
+     * as "metaDescriptionFallback" when the stored meta-description is empty.
+     *
+     * This intentionally does NOT override getMetaDescription() itself: that
+     * raw getter is used by the admin SEO form and its setter round-trip, so
+     * exposing a computed value there would persist the fallback into the real
+     * meta-description column on save.
+     *
+     * The flag lives on the concrete NodeTypeField (not the contracts
+     * interface), so it is read here by duck typing to avoid coupling this
+     * split package to roadiz/core-bundle.
+     */
+    private function addMetaDescriptionFallbackMethod(ClassType $classType): void
+    {
+        $fallbackGetter = null;
+        foreach ($this->nodeType->getFields() as $field) {
+            if (method_exists($field, 'isMetaDescriptionFallback') && $field->isMetaDescriptionFallback()) {
+                $fallbackGetter = $field->getGetterName();
+                break;
+            }
+        }
+
+        if (null === $fallbackGetter) {
+            return;
+        }
+
+        $classType->addMethod('getMetaDescriptionOrFallback')
+            ->setReturnType('string')
+            ->addAttribute(\Override::class)
+            ->setBody(
+                "\$metaDescription = \$this->getMetaDescription();\n"
+                ."if ('' !== \$metaDescription) {\n"
+                ."    return \$metaDescription;\n"
+                ."}\n\n"
+                .'return (string) ($this->'.$fallbackGetter."() ?? '');"
+            )
+        ;
     }
 }

--- a/lib/EntityGenerator/tests/EntityGeneratorMetaDescriptionTest.php
+++ b/lib/EntityGenerator/tests/EntityGeneratorMetaDescriptionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RZ\Roadiz\EntityGenerator\Tests;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use RZ\Roadiz\Contracts\NodeType\NodeTypeInterface;
+use RZ\Roadiz\EntityGenerator\EntityGenerator;
+
+final class EntityGeneratorMetaDescriptionTest extends TestCase
+{
+    use NodeTypeAwareTestTrait;
+
+    private const array OPTIONS = [
+        'parent_class' => '\mock\Entity\NodesSources',
+        'node_class' => '\mock\Entity\Node',
+        'translation_class' => '\mock\Entity\Translation',
+        'document_class' => '\mock\Entity\Document',
+        'document_proxy_class' => '\mock\Entity\NodesSourcesDocument',
+        'custom_form_class' => '\mock\Entity\CustomForm',
+        'custom_form_proxy_class' => '\mock\Entity\NodesSourcesCustomForm',
+        'repository_class' => '\mock\Entity\Repository\NodesSourcesRepository',
+        'use_native_json' => true,
+        'use_api_platform_filters' => true,
+    ];
+
+    /**
+     * @param iterable<\RZ\Roadiz\Contracts\NodeType\NodeTypeFieldInterface> $fields
+     */
+    private function createNodeType(iterable $fields): NodeTypeInterface
+    {
+        $nodeType = $this->createStub(NodeTypeInterface::class);
+        $nodeType->method('getFields')->willReturn(new ArrayCollection([...$fields]));
+        $nodeType->method('getSourceEntityTableName')->willReturn('ns_mock');
+        $nodeType->method('getSourceEntityClassName')->willReturn('NSMock');
+        $nodeType->method('getName')->willReturn('Mock');
+        $nodeType->method('isReachable')->willReturn(true);
+        $nodeType->method('isPublishable')->willReturn(true);
+
+        return $nodeType;
+    }
+
+    private function generate(NodeTypeInterface $nodeType): string
+    {
+        return (new EntityGenerator(
+            $nodeType,
+            $this->getMockNodeTypeResolver(),
+            $this->getMockDefaultValuesResolver(),
+            new SimpleNodeTypeClassLocator(
+                'RZ\Roadiz\EntityGenerator\Tests\Mocks\GeneratedNodesSources',
+                'RZ\Roadiz\EntityGenerator\Tests\Mocks\GeneratedNodesSources\Repository',
+            ),
+            self::OPTIONS,
+        ))->getClassContent();
+    }
+
+    public function testFlaggedFieldGeneratesMetaDescriptionOverride(): void
+    {
+        $content = $this->generate($this->createNodeType([
+            (new SimpleNodeTypeField())
+                ->setName('excerpt')
+                ->setTypeName('markdown')
+                ->setDoctrineType('text')
+                ->setVirtual(false)
+                ->setLabel('Excerpt')
+                ->setMetaDescriptionFallback(true),
+        ]));
+
+        $this->assertStringContainsString('public function getMetaDescriptionOrFallback(): string', $content);
+        $this->assertStringContainsString('$metaDescription = $this->getMetaDescription();', $content);
+        $this->assertStringContainsString('return (string) ($this->getExcerpt() ?? \'\');', $content);
+        // The raw getter must NOT be overridden (would pollute the SEO form round-trip).
+        $this->assertStringNotContainsString('public function getMetaDescription(): string', $content);
+    }
+
+    public function testUnflaggedFieldsGenerateNoOverride(): void
+    {
+        $content = $this->generate($this->createNodeType([
+            (new SimpleNodeTypeField())
+                ->setName('excerpt')
+                ->setTypeName('markdown')
+                ->setDoctrineType('text')
+                ->setVirtual(false)
+                ->setLabel('Excerpt'),
+        ]));
+
+        $this->assertStringNotContainsString('public function getMetaDescriptionOrFallback(): string', $content);
+    }
+}

--- a/lib/EntityGenerator/tests/SimpleNodeTypeField.php
+++ b/lib/EntityGenerator/tests/SimpleNodeTypeField.php
@@ -31,6 +31,7 @@ final class SimpleNodeTypeField implements NodeTypeFieldInterface, SerializableI
     private bool $indexed = true;
     private bool $expanded = false;
     private bool $required = false;
+    private bool $metaDescriptionFallback = false;
     private string $typeName = 'string';
     private string $nodeTypeName = 'NodeType';
     private string $doctrineType = 'string';
@@ -465,6 +466,18 @@ final class SimpleNodeTypeField implements NodeTypeFieldInterface, SerializableI
     public function setRequired(bool $required): SimpleNodeTypeField
     {
         $this->required = $required;
+
+        return $this;
+    }
+
+    public function isMetaDescriptionFallback(): bool
+    {
+        return $this->metaDescriptionFallback;
+    }
+
+    public function setMetaDescriptionFallback(bool $metaDescriptionFallback): SimpleNodeTypeField
+    {
+        $this->metaDescriptionFallback = $metaDescriptionFallback;
 
         return $this;
     }

--- a/lib/Markdown/composer.json
+++ b/lib/Markdown/composer.json
@@ -11,7 +11,8 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1.36",
-        "phpstan/phpdoc-parser": "<2"
+        "phpstan/phpdoc-parser": "<2",
+        "phpunit/phpunit": "^9.6"
     },
     "license": "MIT",
     "authors": [
@@ -25,6 +26,11 @@
     "autoload": {
         "psr-4": {
             "RZ\\Roadiz\\Markdown\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "RZ\\Roadiz\\Markdown\\Tests\\": "tests/"
         }
     },
     "extra": {

--- a/lib/Markdown/src/CommonMark.php
+++ b/lib/Markdown/src/CommonMark.php
@@ -74,10 +74,9 @@ final readonly class CommonMark implements MarkdownInterface
         $markdown = str_replace(['<br>', '<br />', '<br/>'], ' ', $markdown);
         $markdown = strip_tags($markdown);
         /*
-         * Remove ctrl characters
+         * Remove control characters (including DEL).
          */
-        $markdown = preg_replace('[:cntrl:]', '', $markdown);
-        $markdown = preg_replace('/[\x00-\x1F]/', '', (string) $markdown);
+        $markdown = preg_replace('/[\x00-\x1F\x7F]/', '', $markdown);
 
         return $markdown;
     }

--- a/lib/Markdown/src/CommonMark.php
+++ b/lib/Markdown/src/CommonMark.php
@@ -59,4 +59,26 @@ final readonly class CommonMark implements MarkdownInterface
 
         return $html;
     }
+
+    #[\Override]
+    public function strip(?string $markdown = null): ?string
+    {
+        if (!is_string($markdown)) {
+            return null;
+        }
+        /*
+         * Strip Markdown syntax
+         */
+        $markdown = $this->textExtra($markdown);
+        // replace BR with space to avoid merged words.
+        $markdown = str_replace(['<br>', '<br />', '<br/>'], ' ', $markdown);
+        $markdown = strip_tags($markdown);
+        /*
+         * Remove ctrl characters
+         */
+        $markdown = preg_replace('[:cntrl:]', '', $markdown);
+        $markdown = preg_replace('/[\x00-\x1F]/', '', (string) $markdown);
+
+        return $markdown;
+    }
 }

--- a/lib/Markdown/src/MarkdownInterface.php
+++ b/lib/Markdown/src/MarkdownInterface.php
@@ -26,4 +26,9 @@ interface MarkdownInterface
      * Convert Markdown to HTML using only inline HTML elements.
      */
     public function line(?string $markdown = null): string;
+
+    /**
+     * Convert Markdown then strip tags, control characters and replace br with whitespace.
+     */
+    public function strip(?string $markdown = null): ?string;
 }

--- a/lib/Markdown/src/Twig/MarkdownExtension.php
+++ b/lib/Markdown/src/Twig/MarkdownExtension.php
@@ -23,6 +23,8 @@ final class MarkdownExtension extends AbstractExtension
             new TwigFilter('inline_markdown', $this->inlineMarkdown(...), ['is_safe' => ['html']]),
             new TwigFilter('markdownExtra', $this->markdownExtra(...), ['is_safe' => ['html']]),
             new TwigFilter('markdown_extra', $this->markdownExtra(...), ['is_safe' => ['html']]),
+            new TwigFilter('strip_markdown', $this->strip(...)),
+            new TwigFilter('stripMarkdown', $this->strip(...)),
         ];
     }
 
@@ -61,5 +63,14 @@ final class MarkdownExtension extends AbstractExtension
         }
 
         return $this->markdown->textExtra($input, $allowHtml);
+    }
+
+    public function strip(?string $input): string
+    {
+        if (null === $input) {
+            return '';
+        }
+
+        return $this->markdown->strip($input) ?? '';
     }
 }

--- a/lib/Markdown/tests/CommonMarkTest.php
+++ b/lib/Markdown/tests/CommonMarkTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RZ\Roadiz\Markdown\Tests;
+
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\MarkdownConverter;
+use PHPUnit\Framework\TestCase;
+use RZ\Roadiz\Markdown\CommonMark;
+
+final class CommonMarkTest extends TestCase
+{
+    private function createCommonMark(): CommonMark
+    {
+        $environment = new Environment(['html_input' => 'strip']);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $converter = new MarkdownConverter($environment);
+
+        // strip() only relies on the textExtra converter, but the constructor
+        // requires all five converters.
+        return new CommonMark($converter, $converter, $converter, $converter, $converter);
+    }
+
+    /**
+     * @dataProvider stripProvider
+     */
+    public function testStrip(?string $input, ?string $expected): void
+    {
+        $this->assertSame($expected, $this->createCommonMark()->strip($input));
+    }
+
+    /**
+     * @return array<array{0: ?string, 1: ?string}>
+     */
+    public static function stripProvider(): array
+    {
+        return [
+            'null returns null' => [null, null],
+            'plain text is untouched' => ['Hello world', 'Hello world'],
+            'markdown emphasis is stripped' => ['**Hello** _world_', 'Hello world'],
+            'headings are stripped' => ['# Title', 'Title'],
+            'links keep their label only' => ['[Roadiz](https://roadiz.io)', 'Roadiz'],
+            'hard line break becomes a space' => ["Line1  \nLine2", 'Line1 Line2'],
+            'control characters are removed' => ["a\x07b", 'ab'],
+            'DEL character is removed' => ["a\x7Fb", 'ab'],
+        ];
+    }
+
+    public function testStripRemovesHtmlTags(): void
+    {
+        $result = $this->createCommonMark()->strip('Some **bold** text with a [link](https://roadiz.io).');
+
+        $this->assertStringNotContainsString('<', (string) $result);
+        $this->assertStringNotContainsString('>', (string) $result);
+    }
+}

--- a/lib/RoadizCoreBundle/src/Api/Model/NodesSourcesHead.php
+++ b/lib/RoadizCoreBundle/src/Api/Model/NodesSourcesHead.php
@@ -9,10 +9,11 @@ use RZ\Roadiz\Core\AbstractEntities\TranslationInterface;
 use RZ\Roadiz\Core\Handlers\HandlerFactoryInterface;
 use RZ\Roadiz\CoreBundle\Bag\Settings;
 use RZ\Roadiz\CoreBundle\Entity\NodesSources;
-use RZ\Roadiz\CoreBundle\EntityHandler\NodesSourcesHandler;
 use RZ\Roadiz\Documents\Models\BaseDocumentInterface;
+use RZ\Roadiz\Markdown\MarkdownInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Serializer\Attribute as Serializer;
+use Symfony\Component\String\UnicodeString;
 
 #[ApiResource(operations: [])]
 class NodesSourcesHead implements NodesSourcesHeadInterface
@@ -31,6 +32,8 @@ class NodesSourcesHead implements NodesSourcesHeadInterface
         protected readonly HandlerFactoryInterface $handlerFactory,
         #[Serializer\Ignore]
         protected readonly TranslationInterface $defaultTranslation,
+        #[Serializer\Ignore]
+        protected readonly ?MarkdownInterface $markdown = null,
     ) {
     }
 
@@ -86,19 +89,53 @@ class NodesSourcesHead implements NodesSourcesHeadInterface
         return $this->settingsBag->get('site_name', null) ?? null;
     }
 
+    protected function findDescriptionCandidate(): ?string
+    {
+        if (null === $this->nodesSource) {
+            return null;
+        }
+
+        /*
+         * getMetaDescriptionOrFallback() already falls back on a field flagged
+         * as "metaDescriptionFallback" in the generated node-source entity, so
+         * we only need to check the resulting candidate is relevant enough.
+         */
+        $description = $this->nodesSource->getMetaDescriptionOrFallback();
+
+        return $this->isStringDescriptionEligible($description) ? $description : null;
+    }
+
+    protected function isStringDescriptionEligible(mixed $description): bool
+    {
+        return is_string($description) && !empty($description) && mb_strlen($description) > 20;
+    }
+
+    /**
+     * @return array{'title': string, 'description': string|null}
+     */
     #[Serializer\Ignore]
     protected function getDefaultSeo(): array
     {
-        if (null !== $this->nodesSource) {
-            $nodesSourcesHandler = $this->handlerFactory->getHandler($this->nodesSource);
-            if ($nodesSourcesHandler instanceof NodesSourcesHandler) {
-                return $nodesSourcesHandler->getSEO();
-            }
+        if (null === $this->nodesSource) {
+            return [
+                'title' => $this->settingsBag->get('site_name'),
+                'description' => $this->settingsBag->get('seo_description'),
+            ];
+        }
+
+        $description = $this->findDescriptionCandidate();
+
+        if (null !== $description) {
+            $description = (new UnicodeString($this->markdown?->strip($description) ?? $description))
+                ->truncate(160, '…', false)
+                ->toString();
         }
 
         return [
-            'title' => $this->settingsBag->get('site_name'),
-            'description' => $this->settingsBag->get('seo_description'),
+            'title' => ('' != $this->nodesSource->getMetaTitle()) ?
+                $this->nodesSource->getMetaTitle() :
+                $this->nodesSource->getTitle().' – '.$this->settingsBag->get('site_name'),
+            'description' => $description,
         ];
     }
 

--- a/lib/RoadizCoreBundle/src/Api/Model/NodesSourcesHeadFactory.php
+++ b/lib/RoadizCoreBundle/src/Api/Model/NodesSourcesHeadFactory.php
@@ -8,6 +8,7 @@ use RZ\Roadiz\Core\AbstractEntities\TranslationInterface;
 use RZ\Roadiz\Core\Handlers\HandlerFactoryInterface;
 use RZ\Roadiz\CoreBundle\Bag\Settings;
 use RZ\Roadiz\CoreBundle\Entity\NodesSources;
+use RZ\Roadiz\Markdown\MarkdownInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final readonly class NodesSourcesHeadFactory implements NodesSourcesHeadFactoryInterface
@@ -16,6 +17,7 @@ final readonly class NodesSourcesHeadFactory implements NodesSourcesHeadFactoryI
         private Settings $settingsBag,
         private UrlGeneratorInterface $urlGenerator,
         private HandlerFactoryInterface $handlerFactory,
+        private ?MarkdownInterface $markdown = null,
     ) {
     }
 
@@ -27,7 +29,8 @@ final readonly class NodesSourcesHeadFactory implements NodesSourcesHeadFactoryI
             $this->settingsBag,
             $this->urlGenerator,
             $this->handlerFactory,
-            $nodesSources->getTranslation()
+            $nodesSources->getTranslation(),
+            $this->markdown,
         );
     }
 
@@ -39,7 +42,8 @@ final readonly class NodesSourcesHeadFactory implements NodesSourcesHeadFactoryI
             $this->settingsBag,
             $this->urlGenerator,
             $this->handlerFactory,
-            $translation
+            $translation,
+            $this->markdown,
         );
     }
 }

--- a/lib/RoadizCoreBundle/src/Entity/NodeTypeField.php
+++ b/lib/RoadizCoreBundle/src/Entity/NodeTypeField.php
@@ -70,6 +70,13 @@ final class NodeTypeField extends AbstractField implements NodeTypeFieldInterfac
     #[Serializer\Groups(['node_type', 'node_type:import']),]
     private bool $required = false;
 
+    /**
+     * Use this field content as a fallback for the node-source meta-description
+     * when it is left empty. At most one field per node-type can be flagged.
+     */
+    #[Serializer\Groups(['node_type', 'node_type:import']),]
+    private bool $metaDescriptionFallback = false;
+
     #[Serializer\Groups(['node_type'])]
     #[\Override]
     public function getNodeTypeName(): string
@@ -273,6 +280,22 @@ final class NodeTypeField extends AbstractField implements NodeTypeFieldInterfac
     public function setRequired(bool $required): NodeTypeField
     {
         $this->required = $required;
+
+        return $this;
+    }
+
+    /**
+     * Tells if current field content should feed the node-source meta-description
+     * when it is left empty.
+     */
+    public function isMetaDescriptionFallback(): bool
+    {
+        return $this->metaDescriptionFallback;
+    }
+
+    public function setMetaDescriptionFallback(bool $metaDescriptionFallback): NodeTypeField
+    {
+        $this->metaDescriptionFallback = $metaDescriptionFallback;
 
         return $this;
     }

--- a/lib/RoadizCoreBundle/src/Entity/NodesSources.php
+++ b/lib/RoadizCoreBundle/src/Entity/NodesSources.php
@@ -385,7 +385,12 @@ class NodesSources implements PersistableInterface, Loggable, \Stringable
         return $this;
     }
 
-    public function getMetaTitle(): string
+    /**
+     * Final on purpose: like getMetaDescription(), this raw getter is bound to
+     * the admin SEO form and its setter round-trip, so it must never become a
+     * computed value (that would persist the computed value on save).
+     */
+    final public function getMetaTitle(): string
     {
         return $this->metaTitle;
     }
@@ -400,7 +405,13 @@ class NodesSources implements PersistableInterface, Loggable, \Stringable
         return $this;
     }
 
-    public function getMetaDescription(): string
+    /**
+     * Final on purpose: this raw getter is bound to the admin SEO form and its
+     * setter round-trip, so it must never become a computed value (that would
+     * persist the computed value on save). Use getMetaDescriptionOrFallback()
+     * to expose a fallback-aware value instead.
+     */
+    final public function getMetaDescription(): string
     {
         return $this->metaDescription;
     }
@@ -413,6 +424,21 @@ class NodesSources implements PersistableInterface, Loggable, \Stringable
         $this->metaDescription = null !== $metaDescription ? trim($metaDescription) : '';
 
         return $this;
+    }
+
+    /**
+     * Meta-description to expose for SEO, falling back on the content of a
+     * node-type field flagged as "metaDescriptionFallback" when the stored
+     * meta-description is empty.
+     *
+     * This base implementation returns the raw stored meta-description; it is
+     * overridden in generated node-source entities when a field is flagged.
+     * Unlike getMetaDescription(), this computed value is never persisted back,
+     * so it is safe to expose without polluting the real meta-description field.
+     */
+    public function getMetaDescriptionOrFallback(): string
+    {
+        return $this->getMetaDescription();
     }
 
     public function isNoIndex(): bool

--- a/lib/RoadizCoreBundle/src/EntityHandler/NodesSourcesHandler.php
+++ b/lib/RoadizCoreBundle/src/EntityHandler/NodesSourcesHandler.php
@@ -444,15 +444,11 @@ final class NodesSourcesHandler extends AbstractHandler
     }
 
     /**
-     * Get current node-source SEO data.
+     * Get current node-source SEO data.
      *
-     * This method returns a 3-fields array with:
+     * @return array{'title': string, 'description': string|null}
      *
-     * * title
-     * * description
-     * * keywords
-     *
-     * @return array<string>
+     * @deprecated No replacement: SEO should be handled in NodesSourcesHead
      */
     public function getSEO(): array
     {

--- a/lib/RoadizCoreBundle/src/NodeType/Configuration/NodeTypeConfiguration.php
+++ b/lib/RoadizCoreBundle/src/NodeType/Configuration/NodeTypeConfiguration.php
@@ -52,7 +52,19 @@ final class NodeTypeConfiguration implements ConfigurationInterface
 
         $node = $treeBuilder->getRootNode()
             ->isRequired()
+            ->validate()
+                ->ifTrue(fn (array $fields) => count(array_filter(
+                    $fields,
+                    fn (array $field) => $field['metaDescriptionFallback'] ?? false
+                )) > 1)
+                ->thenInvalid('Only one field can be flagged as "metaDescriptionFallback" per node-type.')
+            ->end()
             ->arrayPrototype()
+                ->validate()
+                    ->ifTrue(fn (array $field) => ($field['metaDescriptionFallback'] ?? false)
+                        && !in_array($field['type'] ?? null, ['string', 'text', 'markdown'], true))
+                    ->thenInvalid('A "metaDescriptionFallback" field must be a "string", "text" or "markdown" type.')
+                ->end()
                 ->children()
                     ->scalarNode('name')
                         ->info('Unique field name without spaces or special characters')
@@ -92,6 +104,7 @@ final class NodeTypeConfiguration implements ConfigurationInterface
                     ->booleanNode('visible')->defaultTrue()->end()
                     ->booleanNode('expanded')->defaultFalse()->end()
                     ->booleanNode('required')->defaultFalse()->end()
+                    ->booleanNode('metaDescriptionFallback')->defaultFalse()->end()
                     ->variableNode('defaultValues')->end()
                     ->arrayNode('normalizationContext')
                         ->children()

--- a/lib/RoadizCoreBundle/tests/Api/Model/NodesSourcesHeadTest.php
+++ b/lib/RoadizCoreBundle/tests/Api/Model/NodesSourcesHeadTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RZ\Roadiz\CoreBundle\Tests\Api\Model;
+
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use RZ\Roadiz\Core\AbstractEntities\TranslationInterface;
+use RZ\Roadiz\Core\Handlers\HandlerFactoryInterface;
+use RZ\Roadiz\CoreBundle\Api\Model\NodesSourcesHead;
+use RZ\Roadiz\CoreBundle\Bag\Settings;
+use RZ\Roadiz\CoreBundle\Entity\NodesSources;
+use RZ\Roadiz\Markdown\MarkdownInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+
+final class NodesSourcesHeadTest extends TestCase
+{
+    /**
+     * Build a node-source double reproducing the getMetaDescriptionOrFallback()
+     * override that EntityGenerator emits for a flagged node-type.
+     */
+    private function nodeSource(
+        string $metaDescription = '',
+        ?string $fallback = null,
+        ?string $title = null,
+        ?string $metaTitle = null,
+    ): NodesSources {
+        $nodeSource = new class extends NodesSources {
+            public ?string $fallbackValue = null;
+
+            public function __construct()
+            {
+            }
+
+            #[\Override]
+            public function getMetaDescriptionOrFallback(): string
+            {
+                $metaDescription = $this->getMetaDescription();
+                if ('' !== $metaDescription) {
+                    return $metaDescription;
+                }
+
+                return (string) ($this->fallbackValue ?? '');
+            }
+        };
+        $nodeSource->fallbackValue = $fallback;
+        $nodeSource->setMetaDescription($metaDescription);
+        if (null !== $title) {
+            $nodeSource->setTitle($title);
+        }
+        if (null !== $metaTitle) {
+            $nodeSource->setMetaTitle($metaTitle);
+        }
+
+        return $nodeSource;
+    }
+
+    private function createHead(?NodesSources $nodeSource): NodesSourcesHead
+    {
+        // An empty settings bag is enough: the tested branch does not rely on
+        // any setting but "site_name", which we assert around explicitly.
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry->method('getRepository')->willThrowException(new \RuntimeException('no database in unit test'));
+        $settings = new Settings($managerRegistry, new Stopwatch());
+
+        // Identity strip keeps assertions about length/truncation deterministic;
+        // the real stripping behaviour is covered by CommonMarkTest.
+        $markdown = $this->createStub(MarkdownInterface::class);
+        $markdown->method('strip')->willReturnArgument(0);
+
+        return new NodesSourcesHead(
+            $nodeSource,
+            $settings,
+            $this->createStub(UrlGeneratorInterface::class),
+            $this->createStub(HandlerFactoryInterface::class),
+            $this->createStub(TranslationInterface::class),
+            $markdown,
+        );
+    }
+
+    public function testEligibleMetaDescriptionIsExposed(): void
+    {
+        $head = $this->createHead($this->nodeSource(
+            metaDescription: 'This description is definitely long enough.',
+        ));
+
+        $this->assertSame('This description is definitely long enough.', $head->getMetaDescription());
+    }
+
+    public function testTooShortMetaDescriptionIsDiscarded(): void
+    {
+        $head = $this->createHead($this->nodeSource(metaDescription: 'Too short'));
+
+        $this->assertNull($head->getMetaDescription());
+    }
+
+    public function testMetaDescriptionExactlyAtThresholdIsDiscarded(): void
+    {
+        // 20 characters: the eligibility test requires *more* than 20.
+        $head = $this->createHead($this->nodeSource(metaDescription: str_repeat('a', 20)));
+
+        $this->assertNull($head->getMetaDescription());
+    }
+
+    public function testFallbackIsUsedWhenMetaDescriptionIsEmpty(): void
+    {
+        $head = $this->createHead($this->nodeSource(
+            metaDescription: '',
+            fallback: 'A long enough fallback taken from the content field.',
+        ));
+
+        $this->assertSame('A long enough fallback taken from the content field.', $head->getMetaDescription());
+    }
+
+    public function testTooShortFallbackIsDiscarded(): void
+    {
+        $head = $this->createHead($this->nodeSource(metaDescription: '', fallback: 'Short one'));
+
+        $this->assertNull($head->getMetaDescription());
+    }
+
+    public function testLongDescriptionIsTruncatedTo160Characters(): void
+    {
+        $head = $this->createHead($this->nodeSource(
+            metaDescription: str_repeat('Roadiz content ', 20),
+        ));
+
+        $description = $head->getMetaDescription();
+
+        $this->assertNotNull($description);
+        // truncate(160, '…', cut: false) completes the last word, so the result
+        // hovers around — and may slightly exceed — 160 characters, but must be
+        // far shorter than the 300-character source and carry the ellipsis.
+        $this->assertLessThan(200, mb_strlen($description));
+        $this->assertStringEndsWith('…', $description);
+        $this->assertStringStartsWith('Roadiz content', $description);
+    }
+
+    public function testMetaTitleTakesPrecedenceOverComputedTitle(): void
+    {
+        $head = $this->createHead($this->nodeSource(
+            title: 'Node title',
+            metaTitle: 'Custom SEO title',
+        ));
+
+        $this->assertSame('Custom SEO title', $head->getMetaTitle());
+    }
+
+    public function testTitleFallsBackToNodeTitle(): void
+    {
+        $head = $this->createHead($this->nodeSource(title: 'My node'));
+
+        $this->assertStringStartsWith('My node – ', (string) $head->getMetaTitle());
+    }
+}

--- a/lib/RoadizCoreBundle/translations/validators.en.xlf
+++ b/lib/RoadizCoreBundle/translations/validators.en.xlf
@@ -46,6 +46,10 @@
                 <source>hotspot_area_start_and_end_coordinates_must_be_between_0_and_1</source>
                 <target state="translated">Hotspot area start and end coordinates must be between 0 and 1.</target>
             </trans-unit>
+      <trans-unit id="A meta-description should either be left empty or be longer than 20 characters to stay relevant for SEO." xml:space="preserve" approved="yes">
+                <source>A meta-description should either be left empty or be longer than 20 characters to stay relevant for SEO.</source>
+                <target state="final">A meta-description should either be left empty or be longer than 20 characters to stay relevant for SEO.</target>
+            </trans-unit>
     </body>
   </file>
 </xliff>

--- a/lib/RoadizCoreBundle/translations/validators.fr.xlf
+++ b/lib/RoadizCoreBundle/translations/validators.fr.xlf
@@ -46,6 +46,10 @@
                 <source>hotspot_area_start_and_end_coordinates_must_be_between_0_and_1</source>
                 <target state="final">Les coordonnées de la zone du point d'intérêt doivent être comprises entre 0 et 1.</target>
             </trans-unit>
+      <trans-unit id="A meta-description should either be left empty or be longer than 20 characters to stay relevant for SEO." xml:space="preserve" approved="yes">
+                <source>A meta-description should either be left empty or be longer than 20 characters to stay relevant for SEO.</source>
+                <target state="final">Une méta-description doit être laissée vide ou comporter plus de 20 caractères pour rester pertinente pour le référencement.</target>
+            </trans-unit>
     </body>
   </file>
 </xliff>

--- a/lib/RoadizRozierBundle/src/Form/NodeSource/NodeSourceSeoType.php
+++ b/lib/RoadizRozierBundle/src/Form/NodeSource/NodeSourceSeoType.php
@@ -11,6 +11,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\AtLeastOneOf;
+use Symfony\Component\Validator\Constraints\Blank;
 use Symfony\Component\Validator\Constraints\Length;
 
 final class NodeSourceSeoType extends AbstractType
@@ -26,15 +28,35 @@ final class NodeSourceSeoType extends AbstractType
                 'data-max-length' => 80,
             ],
             'constraints' => [
-                new Length([
-                    'max' => 80,
-                ]),
+                new Length(max: 80),
             ],
         ])
             ->add('metaDescription', TextareaType::class, [
                 'label' => 'metaDescription',
                 'help' => 'nodeSource.metaDescription.help',
                 'required' => false,
+                'attr' => [
+                    'data-max-length' => 160,
+                ],
+                'constraints' => [
+                    /*
+                     * Either leave it empty (a "metaDescriptionFallback" field
+                     * then feeds the head) or write a relevant description: a
+                     * too-short meta-description is discarded at exposition
+                     * (see NodesSourcesHead), so reject it at input time
+                     * instead of silently dropping the editor's text.
+                     */
+                    new AtLeastOneOf(
+                        constraints: [
+                            new Blank(),
+                            // NodesSourcesHead discards candidates of 20 chars or
+                            // fewer (mb_strlen > 20), so require strictly more.
+                            new Length(min: 21),
+                        ],
+                        message: 'A meta-description should either be left empty or be longer than 20 characters to stay relevant for SEO.',
+                        includeInternalMessages: false,
+                    ),
+                ],
             ])
             ->add('noIndex', CheckboxType::class, [
                 'label' => 'nodeSource.noIndex',

--- a/lib/RoadizSolrBundle/src/Solarium/AbstractSolarium.php
+++ b/lib/RoadizSolrBundle/src/Solarium/AbstractSolarium.php
@@ -267,18 +267,14 @@ abstract class AbstractSolarium
 
     public function cleanTextContent(?string $content, bool $stripMarkdown = true): ?string
     {
+        if (true === $stripMarkdown) {
+            return $this->markdown->strip($content);
+        }
+
         if (!is_string($content)) {
             return null;
         }
-        /*
-         * Strip Markdown syntax
-         */
-        if (true === $stripMarkdown) {
-            $content = $this->markdown->textExtra($content);
-            // replace BR with space to avoid merged words.
-            $content = str_replace(['<br>', '<br />', '<br/>'], ' ', $content);
-            $content = strip_tags($content);
-        }
+
         /*
          * Remove ctrl characters
          */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -47,6 +47,7 @@
             <directory>lib/RoadizCoreBundle/tests</directory>
             <directory>lib/Documents/tests</directory>
             <directory>lib/EntityGenerator/tests</directory>
+            <directory>lib/Markdown/tests</directory>
             <directory>lib/OpenId/tests</directory>
             <directory>lib/RoadizSolrBundle/tests</directory>
         </testsuite>
@@ -69,6 +70,7 @@
             <directory>lib/Models/tests</directory>
             <directory>lib/Documents/tests</directory>
             <directory>lib/EntityGenerator/tests</directory>
+            <directory>lib/Markdown/tests</directory>
             <directory>lib/OpenId/tests</directory>
             <directory>lib/RoadizSolrBundle/tests</directory>
         </exclude>

--- a/src/GeneratedEntity/NSArticle.php
+++ b/src/GeneratedEntity/NSArticle.php
@@ -323,4 +323,15 @@ class NSArticle extends NodesSources
     {
         return '[NSArticle] ' . parent::__toString();
     }
+
+    #[\Override]
+    public function getMetaDescriptionOrFallback(): string
+    {
+        $metaDescription = $this->getMetaDescription();
+        if ('' !== $metaDescription) {
+            return $metaDescription;
+        }
+
+        return (string) ($this->getContent() ?? '');
+    }
 }

--- a/src/GeneratedEntity/NSPage.php
+++ b/src/GeneratedEntity/NSPage.php
@@ -976,4 +976,15 @@ class NSPage extends NodesSources
     {
         return '[NSPage] ' . parent::__toString();
     }
+
+    #[\Override]
+    public function getMetaDescriptionOrFallback(): string
+    {
+        $metaDescription = $this->getMetaDescription();
+        if ('' !== $metaDescription) {
+            return $metaDescription;
+        }
+
+        return (string) ($this->getContent() ?? '');
+    }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,6 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>
+        {% block description %}{% endblock %}
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
         <style>
             body {

--- a/templates/bundles/RoadizCoreBundle/nodeSource/default.html.twig
+++ b/templates/bundles/RoadizCoreBundle/nodeSource/default.html.twig
@@ -1,6 +1,9 @@
 {% extends "base.html.twig" %}
 
-{% block title %}{{ webResponse.item.title }}{% endblock %}
+{% block title %}{{ webResponse.head.metaTitle }}{% endblock %}
+{% block description %}{% if webResponse.head.metaDescription %}
+    <meta name="description" content="{{ webResponse.head.metaDescription }}">
+{% endif %}{% endblock %}
 
 {% macro walk_block(block) %}
     <li>{{ block.item.title }}</li>


### PR DESCRIPTION
Closes #458

## Summary

Previously, an empty meta-description fell back to duplicating the meta-title (plus site name) via `NodesSourcesHandler::getSEO`, producing irrelevant, duplicated SEO data. This PR removes that behaviour and replaces it with an **explicit, per-node-type meta-description fallback field**: each node-type may designate one text field whose content feeds the meta-description when none is set, and the exposed value is stripped of markdown, truncated to 160 chars, and omitted entirely when too short (rather than padded with noise).

## Changes

### SEO / node-sources
- Deprecate `NodesSourcesHandler::getSEO()`; always use the `NodesSourcesHead` service instead.
- `NodesSourcesHead` now reads `getMetaDescriptionOrFallback()`, strips markdown, truncates to 160 chars, and returns `null` when the result is too short (< 20 chars) instead of falling back to the title.
- Mark `NodesSources::getMetaDescription()` / `getMetaTitle()` as `final` to prevent generated subclasses from silently overriding (and persisting) computed values.
- SEO form now rejects a meta-description of 20 characters or fewer at input time while still allowing an empty value, so the fallback field can take over. Added `validators.en/fr` translations.

### New `metaDescriptionFallback` node-type field flag
- New `metaDescriptionFallback` node-type-field flag (`NodeTypeField` + config schema). At most one flagged field per node-type, restricted to `string` / `text` / `markdown` types.
- EntityGenerator emits `getMetaDescriptionOrFallback()` on generated node-source entities, returning the flagged field's content when the stored meta-description is empty. It deliberately does **not** override `getMetaDescription()` (the raw getter bound to the admin SEO form), avoiding a computed value being persisted on save.
- `article.yaml` / `page.yaml` node-types and regenerated `NSArticle` / `NSPage` entities updated accordingly.

### Markdown
- New `MarkdownInterface::strip()` method to parse and strip markdown down to plain text.
- Fix `CommonMark::strip()` control-character regex and bootstrap the Markdown package test harness.

### Docs & tests
- Update `web_response` and `node_type_fields` developer docs.
- Add unit tests for `NodesSourcesHead` SEO exposition, EntityGenerator meta-description handling, and `CommonMark::strip()`.
- Update test twig templates.
