### PR TITLE
fix(nodes): use decorated node-type display name

### DIFF
--- a/lib/RoadizCoreBundle/src/Node/UniqueNodeGenerator.php
+++ b/lib/RoadizCoreBundle/src/Node/UniqueNodeGenerator.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ManagerRegistry;
 use RZ\Roadiz\Contracts\NodeType\NodeTypeClassLocatorInterface;
 use RZ\Roadiz\Core\AbstractEntities\TranslationInterface;
-use RZ\Roadiz\CoreBundle\Bag\NodeTypes;
+use RZ\Roadiz\CoreBundle\Bag\DecoratedNodeTypes;
 use RZ\Roadiz\CoreBundle\Entity\Node;
 use RZ\Roadiz\CoreBundle\Entity\NodesSources;
 use RZ\Roadiz\CoreBundle\Entity\NodeType;
@@ -33,7 +33,7 @@ final readonly class UniqueNodeGenerator
         private TranslationRepository $translationRepository,
         private TagRepository $tagRepository,
         private Security $security,
-        private NodeTypes $nodeTypesBag,
+        private DecoratedNodeTypes $nodeTypesBag,
         private NodeTypeClassLocatorInterface $nodeTypeClassLocator,
     ) {
     }
@@ -51,7 +51,12 @@ final readonly class UniqueNodeGenerator
         bool $pushToTop = false,
         bool $flush = true,
     ): NodesSources {
-        $name = $nodeType->getDisplayName().' '.uniqid();
+        /*
+         * Resolve the decorated node-type so any display name override
+         * (NodeTypeDecorator) is honoured in the generated node title.
+         */
+        $displayName = $this->nodeTypesBag->get($nodeType->getName())?->getDisplayName() ?? $nodeType->getDisplayName();
+        $name = $displayName.' '.uniqid();
         $node = new Node();
         $node->setNodeTypeName($nodeType->getName());
         $node->setTtl($nodeType->getDefaultTtl());


### PR DESCRIPTION
When creating a child node (e.g. via the + button of a nodes field or the quick-add tree buttons), UniqueNodeGenerator resolved the node-type from the non-decorated NodeTypes bag, so any display name overridden through a NodeTypeDecorator was ignored and the generated node title used the original display name instead.

Inject DecoratedNodeTypes and resolve the display name from it so the decorator override is honoured in the generated node title.