### PR TITLE
fix(security): pin remote fetches to validated IP

### DIFF
--- a/lib/Documents/composer.json
+++ b/lib/Documents/composer.json
@@ -35,8 +35,9 @@
         "symfony/event-dispatcher": "7.4.*",
         "symfony/filesystem": ">=7.1",
         "symfony/finder": "7.4.*",
-        "symfony/http-foundation": "7.4.*",
+        "symfony/http-client": "7.4.*",
         "symfony/http-client-contracts": "^3.5",
+        "symfony/http-foundation": "7.4.*",
         "symfony/options-resolver": "7.4.*",
         "symfony/serializer": "7.4.*",
         "twig/twig": "^3.21"
@@ -49,7 +50,6 @@
         "phpstan/phpdoc-parser": "<2",
         "phpstan/phpstan-doctrine": "^2.0.13",
         "phpunit/phpunit": "^9.6",
-        "symfony/http-client": "7.4.*",
         "symfony/process": "7.4.*"
     },
     "autoload": {

--- a/lib/Documents/src/DownloadedFile.php
+++ b/lib/Documents/src/DownloadedFile.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace RZ\Roadiz\Documents;
 
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\String\UnicodeString;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class DownloadedFile extends File
 {
@@ -66,24 +69,17 @@ class DownloadedFile extends File
     public static function fromUrl(string $url, ?string $originalName = null): ?DownloadedFile
     {
         try {
-            if (!self::isSafeRemoteUrl($url)) {
+            if (!self::isSafeRemoteScheme($url)) {
                 return null;
             }
 
             $baseName = static::sanitizeFilename(pathinfo($url, PATHINFO_BASENAME));
-            $streamContext = stream_context_create([
-                'http' => [
-                    'follow_location' => 0,
-                    'timeout' => 10,
-                ],
-                'https' => [
-                    'follow_location' => 0,
-                    'timeout' => 10,
-                ],
+            $client = static::createHttpClient();
+            $response = $client->request('GET', $url, [
+                'max_redirects' => 3,
+                'timeout' => 10,
             ]);
-
-            $distantResource = fopen($url, 'r', false, $streamContext);
-            if (false === $distantResource) {
+            if (200 !== $response->getStatusCode()) {
                 return null;
             }
 
@@ -95,11 +91,15 @@ class DownloadedFile extends File
             if (false === $localResource) {
                 throw new \RuntimeException('Unable to open local resource.');
             }
-            $result = \stream_copy_to_stream($distantResource, $localResource);
-            fclose($distantResource);
-            fclose($localResource);
-            if (false === $result) {
-                throw new \RuntimeException('Unable to copy distant stream to local resource.');
+            try {
+                foreach ($client->stream($response) as $chunk) {
+                    fwrite($localResource, $chunk->getContent());
+                }
+                fclose($localResource);
+            } catch (\Throwable $exception) {
+                fclose($localResource);
+                unlink($tmpFile);
+                throw $exception;
             }
 
             $file = new static($tmpFile);
@@ -125,59 +125,38 @@ class DownloadedFile extends File
         return null;
     }
 
-    private static function isSafeRemoteUrl(string $url): bool
+    /**
+     * Any override MUST keep blocking private networks: NoPrivateNetworkHttpClient pins the connection to the
+     * address it validated and re-checks every redirect hop, which is what stops a DNS rebind between the
+     * check and the fetch.
+     */
+    protected static function createHttpClient(): HttpClientInterface
+    {
+        return new NoPrivateNetworkHttpClient(HttpClient::create());
+    }
+
+    /**
+     * Cheap pre-flight, before any network call. Non-HTTP schemes must be rejected here because Symfony
+     * HttpClient throws an InvalidArgumentException — not a RuntimeException — on file:// and php:// URLs.
+     *
+     * Private-address filtering is deliberately NOT done here: resolving the host up front cannot bind the
+     * socket to what it validated (CVE-2026-33486 follow-up). NoPrivateNetworkHttpClient pins the connection
+     * to the address it checked and re-checks every redirect hop, so it owns that responsibility.
+     */
+    private static function isSafeRemoteScheme(string $url): bool
     {
         $parts = parse_url($url);
         if (false === $parts) {
             return false;
         }
 
-        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
-        if (!\in_array($scheme, ['http', 'https'], true)) {
+        if (!\in_array(strtolower((string) ($parts['scheme'] ?? '')), ['http', 'https'], true)) {
             return false;
         }
 
         $host = strtolower((string) ($parts['host'] ?? ''));
-        if ('' === $host) {
-            return false;
-        }
-        if ('localhost' === $host || str_ends_with($host, '.localhost')) {
-            return false;
-        }
 
-        $asciiHost = $host;
-        if (function_exists('idn_to_ascii')) {
-            $idnHost = idn_to_ascii($host, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
-            if (false !== $idnHost) {
-                $asciiHost = strtolower($idnHost);
-            }
-        }
-
-        if (false !== filter_var($asciiHost, FILTER_VALIDATE_IP)) {
-            return self::isGlobalIp($asciiHost);
-        }
-
-        $records = dns_get_record($asciiHost, DNS_A + DNS_AAAA);
-        if (false === $records || 0 === count($records)) {
-            return false;
-        }
-
-        foreach ($records as $record) {
-            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
-            if (null === $ip || !self::isGlobalIp($ip)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static function isGlobalIp(string $ip): bool
-    {
-        return false !== filter_var(
-            $ip,
-            FILTER_VALIDATE_IP,
-            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
-        );
+        // Short-circuit localhost so we never pay a pointless DNS lookup for a host that can only be blocked.
+        return '' !== $host && 'localhost' !== $host && !str_ends_with($host, '.localhost');
     }
 }

--- a/lib/Documents/tests/DownloadedFileTest.php
+++ b/lib/Documents/tests/DownloadedFileTest.php
@@ -6,6 +6,7 @@ namespace RZ\Roadiz\Documents\Tests;
 
 use PHPUnit\Framework\TestCase;
 use RZ\Roadiz\Documents\DownloadedFile;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 class DownloadedFileTest extends TestCase
 {
@@ -109,5 +110,42 @@ class DownloadedFileTest extends TestCase
             ['https://sub.localhost/test.jpg'],
             ['ftp://example.com/test.jpg'],
         ];
+    }
+
+    /**
+     * A DNS rebind answers the guard with a routable address and the connection with a private one.
+     * Guard against it by asserting on the address actually connected to, not the one looked up before.
+     */
+    public function testFromUrlRejectsPrivateAddressAtConnectTime(): void
+    {
+        // IP literal host: passes the pre-connect check without any DNS lookup, then the socket reports 127.0.0.1.
+        MockDownloadedFile::$responses = [new MockResponse('payload', ['primary_ip' => '127.0.0.1'])];
+
+        $this->assertNull(MockDownloadedFile::fromUrl('https://93.184.216.34/test.jpg'));
+    }
+
+    public function testFromUrlRejectsRedirectToPrivateAddress(): void
+    {
+        MockDownloadedFile::$responses = [
+            new MockResponse('', [
+                'http_code' => 302,
+                'primary_ip' => '93.184.216.34',
+                'response_headers' => ['Location: http://127.0.0.1/internal.jpg'],
+            ]),
+            new MockResponse('secret', ['primary_ip' => '127.0.0.1']),
+        ];
+
+        $this->assertNull(MockDownloadedFile::fromUrl('https://93.184.216.34/test.jpg'));
+    }
+
+    public function testFromUrlDownloadsPublicAddress(): void
+    {
+        MockDownloadedFile::$responses = [new MockResponse('payload', ['primary_ip' => '93.184.216.34'])];
+
+        $file = MockDownloadedFile::fromUrl('https://93.184.216.34/test.jpg');
+
+        // Without this, the two rejection tests above would pass on a fromUrl() that never downloads anything.
+        $this->assertNotNull($file);
+        $this->assertSame(7, $file->getSize());
     }
 }

--- a/lib/Documents/tests/MockDownloadedFile.php
+++ b/lib/Documents/tests/MockDownloadedFile.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RZ\Roadiz\Documents\Tests;
+
+use RZ\Roadiz\Documents\DownloadedFile;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Feeds fromUrl() canned responses so the private-network guard can be exercised offline.
+ *
+ * The mock is still wrapped in NoPrivateNetworkHttpClient: the tests assert on the guard, not around it.
+ */
+final class MockDownloadedFile extends DownloadedFile
+{
+    /** @var array<MockResponse> */
+    public static array $responses = [];
+
+    #[\Override]
+    protected static function createHttpClient(): HttpClientInterface
+    {
+        return new NoPrivateNetworkHttpClient(new MockHttpClient(self::$responses));
+    }
+}

--- a/lib/RoadizCoreBundle/config/services.yaml
+++ b/lib/RoadizCoreBundle/config/services.yaml
@@ -465,9 +465,20 @@ services:
     #
     # Media finders
     #
-    RZ\Roadiz\CoreBundle\Document\MediaFinder\UnsplashPictureFinder:
+    # Media finders fetch user-supplied URLs (podcast feeds, oEmbed endpoints): never give them the raw
+    # http_client, or they become an SSRF pivot into the private network.
+    roadiz_core.no_private_network_http_client:
+        class: Symfony\Component\HttpClient\NoPrivateNetworkHttpClient
+        # autoconfigure would inject a logger through the setLogger() deprecated since symfony/http-client 7.1;
+        # the wrapped http_client already logs. kernel.reset is kept to flush its DNS cache between requests.
+        autoconfigure: false
         arguments:
             - '@http_client'
+        tags:
+            - { name: kernel.reset, method: reset }
+    RZ\Roadiz\CoreBundle\Document\MediaFinder\UnsplashPictureFinder:
+        arguments:
+            - '@roadiz_core.no_private_network_http_client'
             - '%roadiz_core.medias.unsplash_client_id%'
     RZ\Roadiz\Documents\MediaFinders\RandomImageFinder:
         alias: RZ\Roadiz\CoreBundle\Document\MediaFinder\UnsplashPictureFinder
@@ -590,7 +601,7 @@ services:
 
     RZ\Roadiz\Documents\MediaFinders\EmbedFinderFactory:
         arguments:
-            - '@http_client'
+            - '@roadiz_core.no_private_network_http_client'
             - '%roadiz_core.medias.supported_platforms%'
 
     RZ\Roadiz\Documents\Renderer\ChainRenderer:


### PR DESCRIPTION
DownloadedFile::fromUrl() resolved the host with dns_get_record(), checked every answer was globally routable, then handed the original hostname to fopen(), which resolved it again. Nothing bound the connection to the addresses that were approved, so an attacker controlling authoritative DNS could answer the check with a public address and the fetch with a private one. This is a bypass of the GHSA-rc55-58f4-687g fix (CVE-2026-33486), affecting 2.7.9 through 2.7.36.

Fetch through NoPrivateNetworkHttpClient instead: it pins the connection to the address it validated, re-checks the address actually connected to, and re-validates every redirect hop. Its subnet list also covers CGNAT, link-local and NAT64 ranges that the previous isGlobalIp() missed. Redirects are re-enabled (max 3) now that each hop is checked; they had been disabled outright since 2.7.9, silently breaking legitimate CDN thumbnails.

Also close an unguarded SSRF sink found while tracing this: AbstractPodcastFinder::getMediaFeed() and AbstractEmbedFinder:: downloadFeedFromAPI() fetched user-supplied URLs with no scheme allowlist and no address check, reaching internal services without any DNS trickery. Media finders now receive a private-network-blocking client from the container instead of the raw http_client.